### PR TITLE
ci(release): change prerelease command back to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prerelease": "bob build",
+    "prepare": "bob build",
     "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",


### PR DESCRIPTION
📝  **DESCRIPTION:**

This PR changes `prerelease` package command back to `prepare` in order to fix the release-it pipeline