### PR TITLE
refactor: type import and props

### DIFF
--- a/src/MagicModalPortal.tsx
+++ b/src/MagicModalPortal.tsx
@@ -8,12 +8,8 @@ import { ANIMATION_DURATION_IN_MS } from './constants/animations';
 import { Dimensions } from 'react-native';
 import { styles } from './MagicModalPortal.styles';
 import ModalContainer, { ModalProps } from 'react-native-modal';
-import {
-  type ModalChildren,
-  type IModal,
-  magicModalRef,
-  NewConfigProps,
-} from './utils/magicModalHandler';
+import { magicModalRef, NewConfigProps } from './utils/magicModalHandler';
+import type { ModalChildren, IModal } from './utils/magicModalHandler';
 
 const { width, height } = Dimensions.get('screen');
 
@@ -86,12 +82,12 @@ export const MagicModalPortal: React.FC = () => {
     <ModalContainer
       ref={modalRefForTests}
       backdropTransitionOutTiming={0}
-      avoidKeyboard={true}
-      swipeDirection={'down'}
+      avoidKeyboard
+      swipeDirection="down"
       deviceHeight={height}
       deviceWidth={width}
       animationOutTiming={ANIMATION_DURATION_IN_MS}
-      statusBarTranslucent={true}
+      statusBarTranslucent
       onBackdropPress={() => hide(MagicModalHideTypes.BACKDROP_PRESSED)}
       onSwipeComplete={() => hide(MagicModalHideTypes.SWIPE_COMPLETED)}
       onBackButtonPress={() => hide(MagicModalHideTypes.BACK_BUTTON_PRESSED)}


### PR DESCRIPTION
📝  **DESCRIPTION:**

- This is to fix compatibility mistake about TypeScript/Babel transpilation. The metro/RN (v0.65.x in my case) can not run with this syntax (using older version of ES/TypeScript, like at the screenshots).


🖼  picture: **PRINTS & GIFS:**

![Simulator Screen Shot - iPhone X - 2022-08-04 at 10 11 06](https://user-images.githubusercontent.com/62335491/182912809-b075b729-d337-4277-97ad-8518cc453af7.png)
![Captura de Tela 2022-08-04 às 14 36 16](https://user-images.githubusercontent.com/62335491/182914941-166007c2-c1f6-49b8-8cf8-43d4b0571395.png)

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

- This PR change the style of import and add clean syntax to the props of `ModalComponent`.
