### PR TITLE
feat!: rename swipeDirection "top" and "bottom" to "up" and "down"

### DIFF
--- a/examples/kitchen-sink/src/app/index.tsx
+++ b/examples/kitchen-sink/src/app/index.tsx
@@ -9,7 +9,7 @@ import { StatusBar } from "expo-status-bar";
 import { ZoomIn, ZoomOut } from "react-native-reanimated";
 
 const showModal = async () => {
-  const swipeDirection = ["top", "bottom", "left", "right"][
+  const swipeDirection = ["up", "down", "left", "right"][
     Math.round(Math.random() * 3)
   ] as Direction;
 
@@ -66,7 +66,7 @@ const showToast = async () => {
   console.log("Opening toast");
 
   const toastResponse = await magicModal.show(() => <Toast />, {
-    swipeDirection: "top",
+    swipeDirection: "up",
     hideBackdrop: true,
     dampingFactor: 0,
     style: {

--- a/packages/modal/src/components/MagicModalPortal/MagicModalPortal.tsx
+++ b/packages/modal/src/components/MagicModalPortal/MagicModalPortal.tsx
@@ -42,6 +42,7 @@ import {
   GenericFunction,
   MagicModalHideTypes,
   ModalChildren,
+  Direction,
 } from "../../constants/types";
 import { defaultConfig, defaultDirection } from "../../constants/defaultConfig";
 
@@ -50,18 +51,18 @@ export const modalRefForTests = React.createRef<any>();
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 const defaultAnimationInMap = {
-  bottom: FadeInDown,
-  top: FadeInUp,
+  up: FadeInUp,
+  down: FadeInDown,
   left: FadeInLeft,
   right: FadeInRight,
-};
+} satisfies Record<Direction, unknown>;
 
 const defaultAnimationOutMap = {
-  bottom: FadeOutDown,
-  top: FadeOutUp,
+  up: FadeOutUp,
+  down: FadeOutDown,
   left: FadeOutLeft,
   right: FadeOutRight,
-};
+} satisfies Record<Direction, unknown>;
 
 /**
  * @description A magic portal that should stay on the top of the app component hierarchy for the modal to be displayed.
@@ -109,7 +110,7 @@ export const MagicModalPortal: React.FC = memo(() => {
     hide,
     show: async (
       newComponent: ModalChildren,
-      newConfig: Partial<ModalProps> = {},
+      newConfig: Partial<ModalProps> = {}
     ) => {
       if (modalContent) await hide(MagicModalHideTypes.MODAL_OVERRIDE);
 
@@ -135,8 +136,14 @@ export const MagicModalPortal: React.FC = memo(() => {
     config.swipeDirection === "left" || config.swipeDirection === "right";
 
   const rangeMap = useMemo(
-    () => ({ left: -width, right: width, top: -height, bottom: height }),
-    [height, width],
+    () =>
+      ({
+        up: -height,
+        down: height,
+        left: -width,
+        right: width,
+      }) satisfies Record<Direction, number>,
+    [height, width]
   );
 
   const pan = Gesture.Pan()
@@ -156,11 +163,11 @@ export const MagicModalPortal: React.FC = memo(() => {
         : prevTranslationY.value;
 
       const shouldDampMap = {
-        bottom: translationValue < 0,
-        top: translationValue > 0,
+        up: translationValue > 0,
+        down: translationValue < 0,
         left: translationValue > 0,
         right: translationValue < 0,
-      };
+      } satisfies Record<Direction, boolean>;
 
       const shouldDamp =
         shouldDampMap[config.swipeDirection ?? defaultDirection];
@@ -179,11 +186,11 @@ export const MagicModalPortal: React.FC = memo(() => {
       const velocityThreshold = config.swipeVelocityThreshold;
 
       const shouldHideMap = {
+        up: event.velocityY < -velocityThreshold,
+        down: event.velocityY > velocityThreshold,
         right: event.velocityX > velocityThreshold,
         left: event.velocityX < -velocityThreshold,
-        top: event.velocityY < -velocityThreshold,
-        bottom: event.velocityY > velocityThreshold,
-      };
+      } satisfies Record<Direction, boolean>;
 
       const shouldHide =
         shouldHideMap[config.swipeDirection ?? defaultDirection];
@@ -206,7 +213,7 @@ export const MagicModalPortal: React.FC = memo(() => {
         rangeMap[config.swipeDirection ?? defaultDirection],
         { velocity: event.velocityX, overshootClamping: true },
         (success) =>
-          success && runOnJS(hide)(MagicModalHideTypes.SWIPE_COMPLETED),
+          success && runOnJS(hide)(MagicModalHideTypes.SWIPE_COMPLETED)
       );
 
       return;
@@ -229,7 +236,7 @@ export const MagicModalPortal: React.FC = memo(() => {
         translationValue,
         [rangeMap[config.swipeDirection ?? defaultDirection], 0],
         [0, 1],
-        Extrapolation.CLAMP,
+        Extrapolation.CLAMP
       ),
     };
   });
@@ -245,7 +252,7 @@ export const MagicModalPortal: React.FC = memo(() => {
           hide(MagicModalHideTypes.BACK_BUTTON_PRESSED);
         }
         return true;
-      },
+      }
     );
     return () => backHandler.remove();
   }, [config.onBackButtonPress, hide, modalContent]);

--- a/packages/modal/src/components/MagicModalPortal/MagicModalPortal.tsx
+++ b/packages/modal/src/components/MagicModalPortal/MagicModalPortal.tsx
@@ -110,7 +110,7 @@ export const MagicModalPortal: React.FC = memo(() => {
     hide,
     show: async (
       newComponent: ModalChildren,
-      newConfig: Partial<ModalProps> = {}
+      newConfig: Partial<ModalProps> = {},
     ) => {
       if (modalContent) await hide(MagicModalHideTypes.MODAL_OVERRIDE);
 
@@ -143,7 +143,7 @@ export const MagicModalPortal: React.FC = memo(() => {
         left: -width,
         right: width,
       }) satisfies Record<Direction, number>,
-    [height, width]
+    [height, width],
   );
 
   const pan = Gesture.Pan()
@@ -213,7 +213,7 @@ export const MagicModalPortal: React.FC = memo(() => {
         rangeMap[config.swipeDirection ?? defaultDirection],
         { velocity: event.velocityX, overshootClamping: true },
         (success) =>
-          success && runOnJS(hide)(MagicModalHideTypes.SWIPE_COMPLETED)
+          success && runOnJS(hide)(MagicModalHideTypes.SWIPE_COMPLETED),
       );
 
       return;
@@ -236,7 +236,7 @@ export const MagicModalPortal: React.FC = memo(() => {
         translationValue,
         [rangeMap[config.swipeDirection ?? defaultDirection], 0],
         [0, 1],
-        Extrapolation.CLAMP
+        Extrapolation.CLAMP,
       ),
     };
   });
@@ -252,7 +252,7 @@ export const MagicModalPortal: React.FC = memo(() => {
           hide(MagicModalHideTypes.BACK_BUTTON_PRESSED);
         }
         return true;
-      }
+      },
     );
     return () => backHandler.remove();
   }, [config.onBackButtonPress, hide, modalContent]);

--- a/packages/modal/src/constants/defaultConfig.ts
+++ b/packages/modal/src/constants/defaultConfig.ts
@@ -1,7 +1,7 @@
 import { ANIMATION_DURATION_IN_MS } from "./animations";
 import { ModalProps } from "./types";
 
-export const defaultDirection = "bottom";
+export const defaultDirection = "down";
 
 export const defaultConfig: ModalProps = {
   animationInTiming: ANIMATION_DURATION_IN_MS,

--- a/packages/modal/src/constants/types.ts
+++ b/packages/modal/src/constants/types.ts
@@ -2,7 +2,7 @@ import Animated from "react-native-reanimated";
 
 export type ModalChildren = React.FC;
 
-export type Direction = "top" | "bottom" | "left" | "right";
+export type Direction = "up" | "down" | "left" | "right";
 
 export type ModalProps = {
   /**
@@ -61,8 +61,8 @@ export type ModalProps = {
   /**
    * Direction of the modal animation.
    * Set to undefined to disable the swipe gesture.
-   * @default "bottom"
-   * @example "top"
+   * @default "down"
+   * @example "up"
    */
   swipeDirection: Direction | undefined;
 


### PR DESCRIPTION
BREAKING CHANGE: To preserve compatibility, swipeDirection "top" and "bottom" properties have been renamed back to "up" and "down". It also makes more sense overall.