### PR TITLE
ci(release): rely on packageManager for pnpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: 🏗 Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 🏗 Get PNPM store directory
         id: pnpm-cache


### PR DESCRIPTION
## Summary
- action-setup@v4 errors when both `version:` and root `packageManager` are set, which broke the publish run after #166 merged (run 26078575325).
- Aligning with branch-validation.yml, which omits `version` and pulls pnpm from `packageManager` (pnpm@9.15.9).
- Unblocks 7.0.0 npm publish.

## Test plan
- [ ] Merge and confirm the 🚀 Publish workflow runs without the "Multiple versions of pnpm specified" error
- [ ] Confirm 7.0.0 lands on npm