### PR TITLE
ci(release): drop pnpm with.version so packageManager wins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: 🏗 Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: 🏗 Get PNPM store directory
         id: pnpm-cache


### PR DESCRIPTION
## Summary

Hotfix for the 🚀 Publish workflow on `main`, which has failed twice consecutively after PR #166 was merged (at 05:39 UTC).

The error is **not** an npm auth issue but a pnpm version conflict:

```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@9.15.9 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

The prior orchestrator commit (`479ad40`) bumped `pnpm/action-setup` from `v2`/`version: 8` to `v4`/`version: 9` but left `with.version` in place, conflicting with `packageManager: pnpm@9.15.9` in `package.json`.

This PR drops `with.version` entirely so `packageManager` wins — mirroring the successful fix applied to `branch-validation.yml` in commit `fa0675c`.

## Test plan

- [x] Branch checkup CI passes
- [ ] 🚀 Publish workflow succeeds on `main` after merge
- [ ] `npm view react-native-magic-modal version` shows the new 7.x release