### PR TITLE
chore(release): 7.0.0

### DIFF
--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 🦄 Magic Modal Changelog 🪄
 
-## Unreleased
+## 7.0.0 (2026-05-19)
 
 ### ⚠ BREAKING CHANGES
 

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-magic-modal",
-  "version": "6.0.6",
+  "version": "7.0.0",
   "type": "module",
   "description": "A magic modal that can be used imperatively from anywhere! 🦄",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bumps `react-native-magic-modal` from `6.0.6` to `7.0.0`
- Renames the `Unreleased` heading in `CHANGELOG.md` to `7.0.0 (2026-05-19)`
- Captures the Expo SDK 52 -> 55 breaking peer-dep bumps (RN 0.83, React 19, Reanimated 4, worklets 0.5) from #161 that earlier failed publish runs lost track of.

## Why a manual bump?
The original `feat!: bump Expo SDK 52 -> 55` lived in the squashed history of #161, but the most recent commits on `main` are `ci(release):` / `chore:` style, so release-it's conventional-changelog plugin computed a `patch` (6.0.6 → 6.0.7). This PR pre-stamps `7.0.0` so the next publish workflow run picks it up verbatim.

Intentionally **no** `feat!:` / `BREAKING CHANGE:` marker on the commit — that would cause release-it to compound the bump again.

## Test plan
- [x] `package.json` version reads `7.0.0`
- [x] `CHANGELOG.md` top section is `## 7.0.0 (2026-05-19)` with the BREAKING CHANGES intact
- [ ] Branch checks pass
- [ ] After merge, Publish workflow ships `7.0.0` (gated on `NPM_TOKEN` rotation — see follow-up issue)