### PR TITLE
chore(modal): sync version, broaden release filter, skip empty publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,31 @@ jobs:
       - name: 🛠️ Build
         run: pnpm run build
 
+      - name: 🔎 Determine next version
+        id: next-version
+        working-directory: packages/modal
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # release-it prints the next version it WOULD publish. If it matches
+          # the version already on disk (== last published), there is nothing
+          # to ship. We disable npm/github side-effects on this probe so it
+          # only computes the version from conventional commits.
+          CURRENT=$(node -p "require('./package.json').version")
+          NEXT=$(pnpm exec release-it --release-version --ci --no-npm --no-github 2>&1 | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -n 1 | tr -d '[:space:]')
+          echo "current=$CURRENT"
+          echo "next=$NEXT"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          if [ -z "$NEXT" ] || [ "$NEXT" = "$CURRENT" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No new version to release. Skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 🚀 Release
+        if: steps.next-version.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/modal/.release-it.js
+++ b/packages/modal/.release-it.js
@@ -54,10 +54,21 @@ export default {
         ],
       },
       /**
-       * Only include commits with (modal) in the message
-       * @param {{ header: string }} commit
+       * Include commits scoped to (modal) and any commit carrying a
+       * BREAKING CHANGE note (regardless of scope). This ensures that
+       * unscoped `feat!:` / `fix!:` commits or commits with a
+       * `BREAKING CHANGE:` footer still trigger a release, while
+       * unrelated chore/deps noise without (modal) scope is ignored.
+       * @param {{ header?: string, notes?: Array<{ title?: string, text?: string }> }} commit
        */
-      commitFilter: (commit) => commit.header.includes("(modal)"),
+      commitFilter: (commit) => {
+        if (commit.header?.includes("(modal)")) return true;
+        if (
+          commit.notes?.some((n) => /BREAKING[- ]CHANGE/i.test(n.title ?? ""))
+        )
+          return true;
+        return false;
+      },
     },
   },
   git: {

--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 🦄 Magic Modal Changelog 🪄
 
+## 7.0.1 (2026-05-19)
+
+### :curly_loop: Continuous Integrations :curly_loop:
+
+* Fixed release-it git push + docs caching (#186)
+* Align package.json version with npm publish 7.0.1
+
 ## 7.0.0 (2026-05-19)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-magic-modal",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "type": "module",
   "description": "A magic modal that can be used imperatively from anywhere! 🦄",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Three small fixes to unblock the release workflow:

1. **Sync `packages/modal/package.json` version `7.0.0` → `7.0.1`** — matches what's currently published on npm. The previous workflow run bumped the registry but the version-bump commit never landed on `main`, so the repo drifted behind.

2. **Broaden `.release-it.js` `commitFilter`** to also count any commit carrying a `BREAKING CHANGE` footer (in `commit.notes`), regardless of scope. Previously only `(modal)`-scoped commits qualified, so an unscoped `feat!:`/`fix!:` would never trigger a release.

3. **Skip the `🚀 Publish` workflow when there is nothing to release.** A new `🔎 Determine next version` step runs `release-it --release-version --ci --no-npm --no-github` and compares the candidate version against `package.json`. If they match (or the probe yields no version), the actual release step is skipped via `if: steps.next-version.outputs.skip != 'true'`. This prevents the workflow from going red with `403 You cannot publish over 7.0.1` when there are no new releasable commits.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm exec release-it --release-version --ci --no-npm --no-github` returns a parseable version locally
- [ ] Next push to `main` without modal commits: workflow stays green and skips release step
- [ ] Next push to `main` with a `(modal)` or `BREAKING CHANGE` commit: workflow publishes as before