### PR TITLE
test: bring jest back to life and run it in CI

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -52,5 +52,8 @@ jobs:
       - name: 🧹 Lint
         run: pnpm run lint
 
+      - name: 🧪 Test
+        run: pnpm run test
+
       - name: 💅 Format
         run: pnpm run format

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ docs
 .envrc
 
 .yarn
+coverage

--- a/packages/modal/coverage/jest-junit.xml
+++ b/packages/modal/coverage/jest-junit.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="jest tests" tests="0" failures="0" errors="0" time="0.621">
-</testsuites>

--- a/packages/modal/jest.config.js
+++ b/packages/modal/jest.config.js
@@ -1,5 +1,8 @@
 export default {
   preset: "jest-expo",
+  // Worklets ships a resolver that skips its `.native` entrypoints, which
+  // otherwise throw "Native part of Worklets doesn't seem to be initialized".
+  resolver: "react-native-worklets/jest/resolver.js",
   testResultsProcessor: "jest-junit",
   transformIgnorePatterns: [
     "node_modules/(?!((jest-)?react-native|react-native-gesture-handler|react-native-reanimated|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -84,7 +84,7 @@
     "jest-junit": "^16.0.0",
     "pod-install": "^0.3.2",
     "prettier": "3.8.3",
-    "react-test-renderer": "^19.2.0",
+    "react-test-renderer": "19.2.0",
     "release-it": "^19.0.3",
     "shx": "^0.4.0",
     "ts-jest": "^29.2.5",

--- a/packages/modal/src/components/MagicModalPortal/MagicModalPortal.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/MagicModalPortal.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Text } from "react-native";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+
+import { MagicModalHideReason } from "../../constants/types";
+import { magicModal } from "../../utils/magicModalHandler";
+import { MagicModalPortal } from "./MagicModalPortal";
+
+const content = "Taveira";
+
+const ModalContent = ({ testID }: { testID: string }) => (
+  <Text testID={testID}>{content}</Text>
+);
+
+describe("MagicModalPortal", () => {
+  it("renders children only after show is called", async () => {
+    render(<MagicModalPortal />);
+
+    expect(screen.queryByTestId("first")).toBeNull();
+
+    act(() => {
+      magicModal.show(() => <ModalContent testID="first" />);
+    });
+
+    expect(await screen.findByTestId("first")).toBeTruthy();
+  });
+
+  it("resolves the show promise with the hide payload", async () => {
+    render(<MagicModalPortal />);
+
+    let result: Promise<unknown> | undefined;
+    let modalID = "";
+
+    act(() => {
+      const modal = magicModal.show(() => <ModalContent testID="second" />);
+      result = modal.promise;
+      modalID = modal.modalID;
+    });
+
+    act(() => {
+      magicModal.hide({ answer: 42 }, { modalID });
+    });
+
+    expect(await result).toEqual({
+      reason: MagicModalHideReason.INTENTIONAL_HIDE,
+      data: { answer: 42 },
+    });
+    expect(screen.queryByTestId("second")).toBeNull();
+  });
+
+  it("hides only the targeted modal from the stack", async () => {
+    render(<MagicModalPortal />);
+
+    let bottomID = "";
+
+    act(() => {
+      bottomID = magicModal.show(() => (
+        <ModalContent testID="bottom" />
+      )).modalID;
+      magicModal.show(() => <ModalContent testID="top" />);
+    });
+
+    expect(await screen.findByTestId("bottom")).toBeTruthy();
+    expect(await screen.findByTestId("top")).toBeTruthy();
+
+    act(() => {
+      magicModal.hide(undefined, { modalID: bottomID });
+    });
+
+    expect(screen.queryByTestId("bottom")).toBeNull();
+    expect(screen.getByTestId("top")).toBeTruthy();
+  });
+
+  it("resolves every pending modal on hideAll", async () => {
+    render(<MagicModalPortal />);
+
+    let promises: Promise<unknown>[] = [];
+
+    act(() => {
+      promises = [
+        magicModal.show(() => <ModalContent testID="a" />).promise,
+        magicModal.show(() => <ModalContent testID="b" />).promise,
+      ];
+    });
+
+    act(() => {
+      magicModal.hideAll();
+    });
+
+    expect(await Promise.all(promises)).toEqual([
+      { reason: MagicModalHideReason.GLOBAL_HIDE_ALL },
+      { reason: MagicModalHideReason.GLOBAL_HIDE_ALL },
+    ]);
+    expect(screen.queryByTestId("a")).toBeNull();
+    expect(screen.queryByTestId("b")).toBeNull();
+  });
+
+  it("hides on backdrop press", async () => {
+    render(<MagicModalPortal />);
+
+    let result: Promise<unknown> | undefined;
+
+    act(() => {
+      result = magicModal.show(() => (
+        <ModalContent testID="backdrop" />
+      )).promise;
+    });
+
+    fireEvent.press(screen.getByTestId("magic-modal-backdrop"));
+
+    expect(await result).toEqual({
+      reason: MagicModalHideReason.BACKDROP_PRESS,
+      data: undefined,
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,7 +190,7 @@ importers:
         version: 9.0.4(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@19.2.4(@types/node@25.9.0))
       '@testing-library/react-native':
         specifier: ^13.3.0
-        version: 13.3.3(jest@29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@5.9.3)))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.0))(react-test-renderer@19.2.6(react@19.2.0))(react@19.2.0)
+        version: 13.3.3(jest@29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@5.9.3)))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -228,8 +228,8 @@ importers:
         specifier: 0.83.6
         version: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.0)
       react-test-renderer:
-        specifier: ^19.2.0
-        version: 19.2.6(react@19.2.0)
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
       release-it:
         specifier: ^19.0.3
         version: 19.2.4(@types/node@25.9.0)
@@ -9028,9 +9028,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -9387,6 +9385,18 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@5.9.3)))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      jest-matcher-utils: 30.4.1
+      picocolors: 1.1.1
+      pretty-format: 30.4.1
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.0)
+      react-test-renderer: 19.2.0(react@19.2.0)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@5.9.3))
+
   '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@5.9.3)))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.0))(react-test-renderer@19.2.6(react@19.2.0))(react@19.2.0)':
     dependencies:
       jest-matcher-utils: 30.4.1
@@ -9398,6 +9408,7 @@ snapshots:
       redent: 3.0.0
     optionalDependencies:
       jest: 29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@5.9.3))
+    optional: true
 
   '@tootallnate/once@2.0.1': {}
 
@@ -13846,6 +13857,7 @@ snapshots:
       react: 19.2.0
       react-is: 19.2.8
       scheduler: 0.27.0
+    optional: true
 
   react@19.2.0: {}
 


### PR DESCRIPTION
Closes #80.

Jest was failing before it ever reached a test file. Two things were broken:

1. Reanimated 4 pulls in `react-native-worklets`, whose `.native` entrypoint throws "Native part of Worklets doesn't seem to be initialized" the moment you import it under Jest. Worklets ships a resolver for exactly this, so `jest.config.js` now points at it.
2. `react-test-renderer` was on `^19.2.0` and resolved to 19.2.6 while Expo pins React to 19.2.0, so RNTL bailed out on the peer check. Pinned it to 19.2.0 like the example app does with React.

Then I brought the suite back. Five tests on the portal covering what people actually rely on: conditional rendering, the show promise resolving with the hide payload, targeting a specific `modalID` in a stack, `hideAll` resolving everything, and backdrop press.

Also wired `pnpm test` into the branch checkup workflow. It wasn't running there at all, which is how this rotted in the first place, and gitignored `coverage/` since jest-junit.xml was tracked and dirtied the tree on every run.

```
PASS src/components/MagicModalPortal/MagicModalPortal.test.tsx
  MagicModalPortal
    ✓ renders children only after show is called
    ✓ resolves the show promise with the hide payload
    ✓ hides only the targeted modal from the stack
    ✓ resolves every pending modal on hideAll
    ✓ hides on backdrop press

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

No dist change, so no release from this one.
