### PR TITLE
fix(modal): stop the swipe gesture from eating taps

### DIFF
--- a/packages/modal/src/components/MagicModal.tsx
+++ b/packages/modal/src/components/MagicModal.tsx
@@ -28,6 +28,8 @@ import { useInternalMagicModal } from "./MagicModalProvider";
 
 export const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
+const TOUCH_SLOP = 10;
+
 export const defaultAnimationInMap = {
   up: FadeInUp,
   down: FadeInDown,
@@ -92,7 +94,10 @@ export const MagicModal = memo(
 
     const pan = Gesture.Pan()
       .enabled(!!config.swipeDirection)
-      .minDistance(1)
+      // Matches the platform touch slop. Anything smaller (we used to use 1)
+      // lets finger jitter during a tap activate the pan, which cancels the
+      // touch on whatever the user was actually pressing inside the modal.
+      .minDistance(TOUCH_SLOP)
       .onStart(() => {
         "worklet";
 


### PR DESCRIPTION
Refs #136.

The swipe gesture wraps the modal's children, and it was set to `minDistance(1)`. One point of travel. On a real device your finger always moves a pixel or two during a tap, RNGH sees that as a pan starting, claims the touch, and cancels the press on whatever button was underneath. That lines up with the report: intermittent, no clear pattern, physical Android device, same buttons working fine outside the modal.

Raised the threshold to 10pt, which is roughly what the platform uses as touch slop and what ScrollView already gets away with. Swipe-to-dismiss still works, it just needs a real drag instead of a twitch.

Worth noting the gesture also isn't axis-constrained, so a horizontal drag activates it even when `swipeDirection` is vertical. Left that alone for now, it's a bigger change and this one covers the reported symptom.

No test for this one, jest can't meaningfully exercise RNGH's native activation thresholds.
