### PR TITLE
chore(ci): stop renovate from fighting expo-doctor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,16 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "description": "The example app's versions are dictated by the installed Expo SDK, and expo-doctor fails the build when they drift. Refresh the lockfile inside the declared ranges, never widen them. SDK jumps are done by hand.",
+      "matchFileNames": ["examples/kitchen-sink/package.json"],
+      "rangeStrategy": "in-range-only"
+    },
+    {
+      "description": "Metro is pinned to whatever line React Native ships with, same reason.",
+      "matchPackageNames": ["metro", "metro-config", "metro-resolver"],
+      "rangeStrategy": "in-range-only"
     }
   ]
 }


### PR DESCRIPTION
Eight of the ten open Renovate PRs are red, all for the same reason: they widen a range that the installed Expo SDK pins, and `expo-doctor` fails the build. react 19.2.6 when SDK 55 wants 19.2.0, gesture-handler 2.31 when it wants ~2.30, metro 0.84 when RN 0.83 ships 0.83. None of them can ever go green, and Renovate keeps rebasing them forever.

Two `in-range-only` rules fix that at the source. Renovate still refreshes the lockfile inside the ranges we declared (which is the useful part, it's what would have caught the SDK 55 patch drift in #204), it just stops rewriting the ranges themselves. SDK jumps stay a deliberate manual thing, same as the 52 -> 55 bump.

Docs flag that `in-range-only` can leave you a few releases behind without telling you. That's the trade I want here, since being "behind" means matching the SDK.
