### PR TITLE
chore(modal): sync version with npm 7.0.2

### DIFF
--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 🦄 Magic Modal Changelog 🪄
 
+## 7.0.2 (2026-05-19)
+
+### :curly_loop: Continuous Integrations :curly_loop:
+
+* Published by the #192 release run, which pushed to npm and then failed before the version bump landed on main
+* Align package.json version with npm publish 7.0.2
+
 ## 7.0.1 (2026-05-19)
 
 ### :curly_loop: Continuous Integrations :curly_loop:

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-magic-modal",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "type": "module",
   "description": "A magic modal that can be used imperatively from anywhere! 🦄",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
npm is on 7.0.2, `packages/modal/package.json` still says 7.0.1. Same drift as #192: the release run for that PR published to npm and then died before the version-bump commit could land on main, so the repo fell a patch behind again.

This just realigns the two. Nothing else changes, and the release probe treats `chore(modal): sync version` as a boundary commit so this won't trigger a publish by itself. It does mean the next real `(modal)` commit bumps from 7.0.2 instead of trying to republish over it.
