### PR TITLE
chore(deps): update expo-doctor to v1.20.1 and drop the metro overrides

### DIFF
--- a/examples/kitchen-sink/metro.config.js
+++ b/examples/kitchen-sink/metro.config.js
@@ -3,27 +3,15 @@
 const { getDefaultConfig } = require("expo/metro-config");
 const path = require("path");
 
-// Find the project and workspace directories
 const projectRoot = __dirname;
 
-const workspaceRoot = path.resolve(projectRoot, "../..");
-
+// `expo/metro-config` already handles monorepos: it watches the workspace
+// root and sets up node_modules resolution. Overriding any of that here just
+// drifts from the defaults, which is what expo-doctor flags.
 /** @type {any} */
-const config = getDefaultConfig(__dirname);
+const config = getDefaultConfig(projectRoot);
 
-// +73.3
 config.watcher.healthCheck.enabled = true;
-
-// 1. Watch all files within the monorepo
-config.watchFolders = [workspaceRoot];
-// 2. Let Metro know where to resolve packages and in what order
-config.resolver.nodeModulesPaths = [
-  path.resolve(projectRoot, "node_modules"),
-  path.resolve(workspaceRoot, "node_modules"),
-];
-
-// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
-config.resolver.disableHierarchicalLookup = true;
 
 const { FileStore } = require("metro-cache");
 config.cacheStores = [

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -52,7 +52,7 @@
     "@babel/core": "^7.20.0",
     "@magic/prettier-config": "workspace:*",
     "@magic/tsconfig": "workspace:*",
-    "expo-doctor": "1.13.3",
+    "expo-doctor": "1.20.1",
     "magic-eslint-config": "workspace:*"
   },
   "prettier": "@magic/prettier-config"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/tsconfig
       expo-doctor:
-        specifier: 1.13.3
-        version: 1.13.3
+        specifier: 1.20.1
+        version: 1.20.1
       magic-eslint-config:
         specifier: workspace:*
         version: link:../../packages/eslint-config
@@ -3751,8 +3751,9 @@ packages:
       expo: '*'
       react-native: '*'
 
-  expo-doctor@1.13.3:
-    resolution: {integrity: sha512-jkVAYdByZf15LCIdumHa/VP9KijFDfeq9gdXD+A2koG8J9ITCKsXXevu2rS1Ibo+YwIkFXu9ovLcB1A/y3kkow==}
+  expo-doctor@1.20.1:
+    resolution: {integrity: sha512-u0QYTm3hTZbuMuNdnvscA1X6Xm31ilQ6uxrf8FfzO0ddpOEBrgVEYp8jXgFOBwrRf6DqJoD2j3eKUTWTqvKVzg==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
     hasBin: true
 
   expo-file-system@55.0.24:
@@ -11272,7 +11273,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-doctor@1.13.3: {}
+  expo-doctor@1.20.1: {}
 
   expo-file-system@55.0.24(expo@55.0.28)(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.0)):
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,9 @@
       "automerge": true
     },
     {
-      "description": "The example app's versions are dictated by the installed Expo SDK, and expo-doctor fails the build when they drift. Refresh the lockfile inside the declared ranges, never widen them. SDK jumps are done by hand.",
+      "description": "The example app's runtime versions are dictated by the installed Expo SDK, and expo-doctor fails the build when they drift. Refresh the lockfile inside the declared ranges, never widen them. SDK jumps are done by hand.",
       "matchFileNames": ["examples/kitchen-sink/package.json"],
+      "matchDepTypes": ["dependencies"],
       "rangeStrategy": "in-range-only"
     },
     {


### PR DESCRIPTION
Supersedes #174.

Renovate's expo-doctor bump has been red for two months. The newer doctor runs 19 checks instead of 15, and one of the new ones flags our `metro.config.js`: we hand-roll `watchFolders`, `nodeModulesPaths` and `disableHierarchicalLookup` from the old Expo monorepo recipe, and `expo/metro-config` has done all of that on its own for a few SDKs now. The manual version drifts, which is exactly what doctor is complaining about.

So this deletes them and takes the defaults. What's left is the cache store (worth keeping, it stops the cache being shared across projects) and the watcher healthcheck.

```
Running 19 checks on your project...
19/19 checks passed. No issues detected!
```

And the bundle still resolves through the workspace link, which is the thing those overrides existed to make work:

```
iOS Bundled 6247ms examples/kitchen-sink/index.js (1473 modules)
› ios bundles (1): _expo/static/js/ios/index-b0c699b7b8c097ea6ee7e4d9207a9545.hbc (3.9MB)
```

One tweak to #206 rides along: I scoped the kitchen-sink `in-range-only` rule to `dependencies`. As written it also caught devDependencies, which would have frozen expo-doctor at whatever exact version it's pinned to forever. The SDK-pinned things we care about are all runtime deps.