### PR TITLE
chore(ci): update actions/checkout to v6 and actions/cache to v5

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Setup PNPM
         uses: pnpm/action-setup@v4
@@ -25,7 +25,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Setup PNPM
         uses: pnpm/action-setup@v2
@@ -40,7 +40,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -53,7 +53,7 @@ jobs:
           node-version: 20.x
 
       - name: "📦 Cache Node Modules"
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5.0.5
         id: cache-node-modules
         with:
           path: node_modules

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Select Xcode 26 (Swift 6.1+ for expo-modules-core)
         run: |
@@ -113,7 +113,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -135,11 +135,11 @@ jobs:
           echo "CCACHE_INODECACHE=true" >> "$GITHUB_ENV"
 
       # Split restore + save so the warmed caches get uploaded even when the
-      # later maestro step fails. actions/cache@v4 only saves on whole-job
+      # later maestro step fails. actions/cache only saves on whole-job
       # success; restore/save lets us save unconditionally.
       - name: 🗄 Restore ccache compiler cache
         id: ccache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -148,7 +148,7 @@ jobs:
 
       - name: 🗄 Restore CocoaPods (specs + downloaded sources)
         id: pods-cache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cocoapods
@@ -159,7 +159,7 @@ jobs:
 
       - name: 🗄 Restore iOS Pods/build/DerivedData
         id: ios-cache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ${{ env.EXAMPLE_DIR }}/ios/Pods
@@ -247,14 +247,14 @@ jobs:
       # GHA cache quota re-uploading identical contents.
       - name: 💾 Save ccache compiler cache
         if: always() && steps.ccache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
       - name: 💾 Save CocoaPods cache
         if: always() && steps.pods-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ~/.cocoapods
@@ -263,7 +263,7 @@ jobs:
 
       - name: 💾 Save iOS Pods/build/DerivedData cache
         if: always() && steps.ios-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ${{ env.EXAMPLE_DIR }}/ios/Pods

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Need full history so the no-op probe below can locate the last
           # release boundary commit and grep for qualifying commits since.
@@ -35,7 +35,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -48,7 +48,7 @@ jobs:
           node-version: 20.x
 
       - name: "📦 Cache Node Modules"
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5.0.5
         id: cache-node-modules
         with:
           path: node_modules


### PR DESCRIPTION
Renovate had these as #200 and #199 and then autoclosed both without merging, so main is still on v4 everywhere. Same diff, reapplied by hand.

Both majors are just the Node 24 runtime move, which is the thing every run has been warning about ("Node.js 20 actions are deprecated... forced to Node.js 24 by default starting June 2nd, 2026"). No input or behaviour changes on our side.

Only the version tags move. Worth watching the first e2e run since it's the heaviest cache user, but restore/save keys are untouched.