### PR TITLE
chore(release): sync magic modal version with npm 7.0.3

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-magic-modal",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "type": "module",
   "description": "A magic modal that can be used imperatively from anywhere! 🦄",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
7.0.3 is live on npm but `packages/modal/package.json` on main still says 7.0.2. Same drift #207 fixed for 7.0.2, same follow-up.

This is expected, not a bug in the release: `.release-it.js` sets `push: false` on purpose, so the bump commit lives and dies on the runner. The comment there explains why (GH_PAT gets rejected by branch protection, and pushing after publish would brick the workflow mid-release). The tag and GitHub Release land fine, only the manifest lags.

Version bump only, nothing else touched.

## Why it matters

`latestVersion` reads from `magic-modal-*` tags, and `magic-modal-7.0.3` exists, so the next release still computes 7.0.4 correctly. This is mostly about main not lying about what's published.

## The actual fix

Rotate `GH_PAT` with `contents: write` plus a branch-protection bypass, then flip `push` back to `true` in `.release-it.js` and these sync PRs stop being a thing. There's already a TODO for it in the config. Worth doing, `NPM_TOKEN` was stale the same way and cost four failed release runs before it got rotated.
