### PR TITLE
fix(ci): stop turbo from swallowing the docs task

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
     "access": "public"
   },
   "scripts": {
-    "lint": "turbo lint",
-    "lint:fix": "turbo lint:fix",
-    "format": "turbo format",
-    "format:fix": "turbo format:fix",
-    "typecheck": "turbo typecheck",
-    "start": "turbo start",
-    "test": "turbo test",
-    "build": "turbo build",
+    "lint": "turbo run lint",
+    "lint:fix": "turbo run lint:fix",
+    "format": "turbo run format",
+    "format:fix": "turbo run format:fix",
+    "typecheck": "turbo run typecheck",
+    "start": "turbo run start",
+    "test": "turbo run test",
+    "build": "turbo run build",
     "release": "turbo run release --filter=react-native-magic-modal",
-    "docs": "turbo docs",
-    "doctor": "turbo doctor"
+    "docs": "turbo run docs",
+    "doctor": "turbo run doctor"
   },
   "config": {
     "commitizen": {

--- a/packages/modal/.prettierignore
+++ b/packages/modal/.prettierignore
@@ -4,3 +4,5 @@ CHANGELOG.md
 coverage
 .turbo
 junit.xml
+README.md
+docs

--- a/packages/modal/tsconfig.json
+++ b/packages/modal/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "extends": ["expo/tsconfig.base", "@magic/tsconfig/base.json"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "docs"],
   "include": [".", ".release-it.js"],
   "compilerOptions": {
     "jsx": "react-native",
     "outDir": "dist",
     "baseUrl": ".",
+    "rootDir": ".",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   }
 }


### PR DESCRIPTION
The Docs workflow has failed all 11 of its runs, going back to the Expo 55 bump in May, so the site has never deployed.

turbo 2 ships a `docs` subcommand of its own, it searches the Turborepo docs and wants a `<QUERY>`, so the root `turbo docs` script never reached the workspace task:

```
> turbo docs
 ERROR  the following required arguments were not provided:
   <QUERY>
```

All root scripts now use `turbo run <task>` so the next builtin they add doesn't quietly take over another one of ours. `docs` is the only one that collides today.

typedoc then ran, and failed on its own:

```
error TS2209: The project root is ambiguous, but is required to resolve export map entry '.'
in file 'packages/eslint-config/package.json'. Supply the `rootDir` compiler option to disambiguate.
```

The modal tsconfig has `include: ["."]`, so `eslint.config.js` is part of the program and TS can't resolve `magic-eslint-config`'s export map without a rootDir. Added `"rootDir": "."`.

`docs` is now excluded from that tsconfig, because typedoc writes the site into `packages/modal/docs` and then typechecks its own bundled assets on the next run. The generated `README.md` is in `.prettierignore` for the same reason, `pnpm docs` followed by `pnpm format` was failing on a file that isn't checked in.

Ran `pnpm run docs` twice in a row, green both times, site lands in `packages/modal/docs`. Also typecheck, lint, test, build and format.
