### PR TITLE
feat(modal): add update() to swap a modal's content in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ const QuickModal = ({ text }) => {
 };
 
 const handleQuickModal = async () => {
-  const { modalId } = magicModal.show(QuickModal);
+  const { modalID } = magicModal.show(QuickModal);
 
   // Wait for 2 seconds before closing the modal
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   // Note that it's usually preferrable to use the `hide` method from the modal context
   // You can even put it inside useEffects to handle auto-dismissal for you.
-  magicModal.hide({ modalId });
+  magicModal.hide(undefined, { modalID });
 };
 
 export const MainScreen = () => {
@@ -200,6 +200,30 @@ export const MainScreen = () => {
   );
 };
 ```
+
+`show` also hands you an `update` function, for when the data driving the modal lives outside of it:
+
+```js
+import { magicModal } from "react-native-magic-modal";
+
+const UploadModal = ({ progress }) => (
+  <View>
+    <Text>Uploading, {progress}%</Text>
+  </View>
+);
+
+const handleUpload = async (file) => {
+  const { modalID, update } = magicModal.show(() => <UploadModal progress={0} />);
+
+  await uploadFile(file, {
+    onProgress: (progress) => update(() => <UploadModal progress={progress} />),
+  });
+
+  magicModal.hide(undefined, { modalID });
+};
+```
+
+The modal itself stays put: same position in the stack, same backdrop, and the promise from `show` keeps waiting. Only the content is swapped, and it's a new component, so it mounts from scratch and anything it kept in `useState` is gone. If the state belongs to the modal, drive it from inside with a store or context instead.
 
 Refer to the [kitchen-sink example](examples/kitchen-sink) for detailed usage scenarios.
 

--- a/examples/kitchen-sink/src/app/index.tsx
+++ b/examples/kitchen-sink/src/app/index.tsx
@@ -89,6 +89,26 @@ const showZoomInModal = async () => {
   });
 };
 
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const showUpdatingModal = async () => {
+  const { modalID, update } = magicModal.show(() => (
+    <ExampleModal body="Closing in 3..." />
+  ));
+
+  await wait(1000);
+  update(() => <ExampleModal body="Closing in 2..." />);
+
+  await wait(1000);
+  update(() => <ExampleModal body="Closing in 1..." />);
+
+  await wait(1000);
+  magicModal.hide(undefined, { modalID });
+};
+
 const showNoFullWindowOverlayModal = async () => {
   magicModal.disableFullWindowOverlay();
   await magicModal.show(() => <ExampleModal />).promise;
@@ -130,6 +150,9 @@ export default () => {
       </Pressable>
       <Pressable style={styles.button} onPress={showZoomInModal}>
         <Text style={styles.buttonText}>Show Zoom In Modal</Text>
+      </Pressable>
+      <Pressable style={styles.button} onPress={showUpdatingModal}>
+        <Text style={styles.buttonText}>Show Updating Modal</Text>
       </Pressable>
       <Pressable style={styles.button} onPress={showToast}>
         <Text style={styles.buttonText}>Show Toast</Text>

--- a/examples/kitchen-sink/src/components/ExampleModal.tsx
+++ b/examples/kitchen-sink/src/components/ExampleModal.tsx
@@ -5,14 +5,14 @@ import { useMagicModal } from "react-native-magic-modal";
 
 import { showToast } from "./Toast";
 
-export const ExampleModal = () => {
+export const ExampleModal = ({ body }: { body?: string }) => {
   const { hide } = useMagicModal<string>();
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Example Modal</Text>
       <Text style={styles.body}>
-        This is an example to showcase the imperative Magic Modal!
+        {body ?? "This is an example to showcase the imperative Magic Modal!"}
       </Text>
       <Pressable
         testID="close-modal-button"

--- a/packages/modal/src/components/MagicModalPortal/MagicModalPortal.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/MagicModalPortal.test.tsx
@@ -95,6 +95,79 @@ describe("MagicModalPortal", () => {
     expect(screen.queryByTestId("b")).toBeNull();
   });
 
+  it("swaps the content without closing the modal", async () => {
+    render(<MagicModalPortal />);
+
+    let update: (component: React.FC) => void = () => {};
+    let result: Promise<unknown> | undefined;
+    let resolved = false;
+
+    act(() => {
+      const modal = magicModal.show(() => <ModalContent testID="before" />);
+      update = modal.update;
+      result = modal.promise;
+      void result.then(() => {
+        resolved = true;
+      });
+    });
+
+    expect(await screen.findByTestId("before")).toBeTruthy();
+
+    act(() => {
+      update(() => <ModalContent testID="after" />);
+    });
+
+    expect(await screen.findByTestId("after")).toBeTruthy();
+    expect(screen.queryByTestId("before")).toBeNull();
+    expect(screen.getByTestId("magic-modal-backdrop")).toBeTruthy();
+    expect(resolved).toBe(false);
+  });
+
+  it("updates only the targeted modal", async () => {
+    render(<MagicModalPortal />);
+
+    let updateBottom: (component: React.FC) => void = () => {};
+
+    act(() => {
+      updateBottom = magicModal.show(() => (
+        <ModalContent testID="bottom" />
+      )).update;
+      magicModal.show(() => <ModalContent testID="top" />);
+    });
+
+    act(() => {
+      updateBottom(() => <ModalContent testID="bottom-updated" />);
+    });
+
+    expect(await screen.findByTestId("bottom-updated")).toBeTruthy();
+    expect(screen.getByTestId("top")).toBeTruthy();
+    expect(screen.queryByTestId("bottom")).toBeNull();
+  });
+
+  it("ignores updates for a modal that is already hidden", async () => {
+    render(<MagicModalPortal />);
+
+    let update: (component: React.FC) => void = () => {};
+    let modalID = "";
+
+    act(() => {
+      const modal = magicModal.show(() => <ModalContent testID="gone" />);
+      update = modal.update;
+      modalID = modal.modalID;
+    });
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    act(() => {
+      update(() => <ModalContent testID="zombie" />);
+    });
+
+    expect(screen.queryByTestId("zombie")).toBeNull();
+    expect(screen.queryByTestId("gone")).toBeNull();
+  });
+
   it("hides on backdrop press", async () => {
     render(<MagicModalPortal />);
 

--- a/packages/modal/src/components/MagicModalPortal/MagicModalPortal.tsx
+++ b/packages/modal/src/components/MagicModalPortal/MagicModalPortal.tsx
@@ -12,6 +12,7 @@ import FullWindowOverlay from "react-native-screens/src/components/FullWindowOve
 import type {
   GlobalHideFunction,
   GlobalShowFunction,
+  GlobalUpdateFunction,
   ModalChildren,
   ModalProps,
 } from "../../constants/types";
@@ -93,6 +94,31 @@ export const MagicModalPortal: React.FC = memo(() => {
     });
   }, []);
 
+  const update = useCallback<GlobalUpdateFunction>(
+    (newComponent, { modalID }) => {
+      setModals((prevModals) => {
+        const currentModal = prevModals.find((modal) => modal.id === modalID);
+
+        if (!currentModal) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[UPDATE EVENT IGNORED] No modal found with id: ${modalID}. It might have already been hidden.`,
+          );
+          return prevModals;
+        }
+
+        if (currentModal.component === newComponent) {
+          return prevModals;
+        }
+
+        return prevModals.map((modal) =>
+          modal.id === modalID ? { ...modal, component: newComponent } : modal,
+        );
+      });
+    },
+    [],
+  );
+
   const show = useCallback<GlobalShowFunction>(
     (newComponent, newConfig) => {
       const modalID = generatePseudoRandomID();
@@ -121,9 +147,12 @@ export const MagicModalPortal: React.FC = memo(() => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         promise: hidePromise as any,
         modalID,
+        update: (updatedComponent: ModalChildren) => {
+          update(updatedComponent, { modalID });
+        },
       } as const;
     },
-    [_hide],
+    [_hide, update],
   );
 
   useEffect(() => {

--- a/packages/modal/src/constants/types.ts
+++ b/packages/modal/src/constants/types.ts
@@ -95,6 +95,16 @@ export type GlobalHideFunction = <T>(
 
 export type GlobalHideAllFunction = () => void;
 
+/**
+ * Swaps the content of the modal it came from. Returned by {@link GlobalShowFunction}.
+ */
+export type ModalUpdateFunction = (newComponent: ModalChildren) => void;
+
+export type GlobalUpdateFunction = (
+  newComponent: ModalChildren,
+  options: { modalID: string },
+) => void;
+
 export type EnableFullWindowOverlayFunction = () => void;
 
 export type DisableFullWindowOverlayFunction = () => void;
@@ -117,4 +127,5 @@ export type GlobalShowFunction = <T>(
 ) => {
   promise: Promise<HideReturn<T>>;
   modalID: string;
+  update: ModalUpdateFunction;
 };

--- a/packages/modal/src/utils/magicModalHandler.ts
+++ b/packages/modal/src/utils/magicModalHandler.ts
@@ -76,7 +76,15 @@ export const magicModal = {
    * @description Pushes a modal to the Stack, it will be displayed on top of the others.
    * @param newComponent Recieves a function that returns a modal component.
    * @param newConfig Recieves {@link NewConfigProps}  to override the default configs.
-   * @returns Returns a Promise that resolves with the {@link hide} props when the Modal is closed. If it were closed automatically, without the manual use of {@link hide}, the return would be one of {@link HideReturn}
+   * @returns `promise`, which resolves with the {@link hide} props when the Modal is closed (if it were closed automatically, without the manual use of {@link hide}, the return would be one of {@link HideReturn}), the `modalID`, and an `update` function that swaps the modal's content while it stays open.
+   * @example
+   * ```js
+   * const { update } = magicModal.show(() => <ExampleModal step={1} />);
+   * update(() => <ExampleModal step={2} />);
+   * ```
+   * Prefer keeping state inside the modal component when you can. `update` is for data that
+   * lives outside of it and can't reach in. The content is a new component, so it mounts from
+   * scratch: anything the old one held in `useState` is gone.
    */
   show,
   /**


### PR DESCRIPTION
Closes #158.

`show()` now returns an `update` alongside `promise` and `modalID`:

```js
const { update } = magicModal.show(() => <UploadModal progress={0} />);
update(() => <UploadModal progress={42} />);
```

I went with the handle shape from the issue thread instead of a global `magicModal.update(component, { modalID })`. You already hold the handle for `hide`, and updating a modal you don't have a handle to is easy to get wrong.

The modal keeps its place in the stack, its backdrop and its pending promise. Only the stack entry's `component` is swapped, so the wrapper animations don't replay. Updating with the same function is a no-op, and updating a modal that's already been hidden logs and returns, same as `hide`.

It doesn't preserve state inside the content. React reconciles by element type and every `update` passes a new function, so the subtree mounts from scratch. That's in the README and the typedoc, along with the reminder to keep state inside the modal when the data can reach it.

Tests: the content swaps while the modal stays open, only the targeted modal in a stack changes, updates after a hide are ignored.

The README's imperative hide example was wrong while I was in there, it used `modalId` and the pre-7.0 single-argument `hide`. kitchen-sink also has a "Show Updating Modal" button now, which counts down in place before closing itself.
