### PR TITLE
fix(deps): drop the duplicate hasown entry that broke the lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4220,10 +4220,6 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
-    engines: {node: '>= 0.4'}
-
   header-case@2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
 
@@ -11828,10 +11824,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hasown@2.0.4:
-    dependencies:
-      function-bind: 1.1.2
 
   hasown@2.0.4:
     dependencies:


### PR DESCRIPTION
`pnpm install --frozen-lockfile` fails on a clean checkout of main:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken: duplicated mapping key (4223:3)
```

717dcc7 added a second `hasown@2.0.4` block to both the `packages:` and the `snapshots:` section. YAML rejects duplicate mapping keys, so pnpm won't parse the file.

Both copies are byte-identical, so I deleted the second of each pair. Eight lines gone.

Branch Checkup didn't catch it because it's `branches-ignore: main`, and the open renovate PRs each carry their own regenerated lockfile, so they install fine. This PR exercises the same path on a branch that inherits main's lockfile.

Verified against the repo's pinned pnpm 9.15.9:

```
Scope: all 6 workspace projects
Lockfile is up to date, resolution step is skipped
Done in 1.4s using pnpm v9.15.9
```
