### PR TITLE
chore(deps): move the pnpm settings out of .npmrc and bump pnpm to 10

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-node-linker=hoisted
-dedupe-direct-deps=true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magic",
   "version": "0.0.0",
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GSTJ/react-native-magic-modal.git"
@@ -41,16 +41,5 @@
   },
   "devDependencies": {
     "turbo": "^2.5.4"
-  },
-  "pnpm": {
-    "overrides": {
-      "metro": "^0.83.3",
-      "metro-resolver": "^0.83.3",
-      "metro-config": "^0.83.3",
-      "@expo/metro-runtime": "55.0.12",
-      "undici": "^6.27.0",
-      "lodash": "^4.18.0",
-      "tmp": "^0.2.6"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,18 @@ packages:
   - tools/*
   - packages/*
   - examples/*
+
+nodeLinker: hoisted
+dedupeDirectDeps: true
+
+overrides:
+  "metro": "^0.83.3"
+  "metro-resolver": "^0.83.3"
+  "metro-config": "^0.83.3"
+  "@expo/metro-runtime": "55.0.12"
+  "undici": "^6.27.0"
+  "lodash": "^4.18.0"
+  "tmp": "^0.2.6"
+
+onlyBuiltDependencies:
+  - "@swc/core"


### PR DESCRIPTION
Moves `node-linker`, `dedupe-direct-deps` and the seven `pnpm.overrides` entries into `pnpm-workspace.yaml`, deletes `.npmrc`, and takes `packageManager` from `pnpm@9.15.9` to `pnpm@10.34.5`. `pnpm-lock.yaml` is untouched.

Every `npm` command in the repo prints:

```
npm warn Unknown project config "node-linker". This will stop working in the next major version of npm.
npm warn Unknown project config "dedupe-direct-deps". This will stop working in the next major version of npm.
```

Those are pnpm settings in `.npmrc`, which npm also reads. Moving them on their own would have flipped `node_modules` from hoisted to isolated, because pnpm 9.15.9 doesn't read settings from `pnpm-workspace.yaml`. I tested each combination against a scratch workspace:

| pnpm | `.npmrc` | `pnpm-workspace.yaml` |
| --- | --- | --- |
| 9.15.9 | hoisted | isolated |
| 10.0.0 | hoisted | isolated |
| 10.28.2 | hoisted | hoisted |
| 10.34.5 | hoisted | hoisted |
| 11.17.0 | isolated | hoisted |

The bump also clears the warning a global pnpm 11 prints here before it delegates to the pinned version:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides".
```

Three of those seven overrides (`undici`, `lodash`, `tmp`) are the dependabot pins from #216. pnpm 11 doesn't read them from `package.json`, so on 11 they'd be gone from any fresh resolve.

pnpm 10 skips dependency build scripts unless they're listed. `@swc/core` was the only one it flagged, so it's in `onlyBuiltDependencies`.

## Verification

`git diff` on `pnpm-lock.yaml` is empty. If the overrides had stopped applying, `--frozen-lockfile` would have failed.

- `pnpm install --frozen-lockfile` from an empty `node_modules`: `Lockfile is up to date, resolution step is skipped`
- `node_modules/.modules.yaml` reports `nodeLinker: hoisted`
- `@swc/core` postinstall runs
- Four overrides spot-checked in the installed tree: lodash 4.18.1, undici 6.28.0, tmp 0.2.7, metro 0.83.7
- `turbo run typecheck lint test build --force`, 7 tasks, all pass
- `npm config list` prints no unknown-config warnings

I stopped at 10.x rather than going straight to 11, to keep it to one major at a time.
