### PR TITLE
chore(deps): bump prettier to 3.9.6 across the workspace

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -83,7 +83,7 @@
     "jest-expo": "^55.0.17",
     "jest-junit": "^16.0.0",
     "pod-install": "^0.3.2",
-    "prettier": "3.8.3",
+    "prettier": "3.9.6",
     "react-test-renderer": "19.2.0",
     "release-it": "^19.0.3",
     "shx": "^0.4.0",

--- a/packages/modal/src/constants/types.ts
+++ b/packages/modal/src/constants/types.ts
@@ -46,8 +46,7 @@ export type ModalProps = {
    * @example ({ hide }) => { console.log('Back button pressed'); hide({ reason: MagicModalHideReason.BACK_BUTTON_PRESS }); }
    */
   onBackButtonPress:
-    | (({ hide }: { hide: HookHideFunction }) => void)
-    | undefined;
+    (({ hide }: { hide: HookHideFunction }) => void) | undefined;
 
   /**
    * Function to be called when the backdrop is pressed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
         specifier: ^0.3.2
         version: 0.3.10
       prettier:
-        specifier: 3.8.3
-        version: 3.8.3
+        specifier: 3.9.6
+        version: 3.9.6
       react-native:
         specifier: 0.83.6
         version: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0)
@@ -257,10 +257,10 @@ importers:
     dependencies:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.4.2
-        version: 4.7.1(prettier@3.8.3)
+        version: 4.7.1(prettier@3.9.6)
       prettier:
-        specifier: ^3.5.3
-        version: 3.8.3
+        specifier: ^3.9.6
+        version: 3.9.6
     devDependencies:
       '@magic/tsconfig':
         specifier: workspace:*
@@ -5708,11 +5708,6 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   prettier@3.9.6:
     resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
@@ -8198,13 +8193,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.3)':
+  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.9.6)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      prettier: 3.8.3
+      prettier: 3.9.6
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
@@ -13622,8 +13617,6 @@ snapshots:
   prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
-
-  prettier@3.8.3: {}
 
   prettier@3.9.6: {}
 

--- a/tools/prettier/package.json
+++ b/tools/prettier/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.4.2",
-    "prettier": "^3.5.3"
+    "prettier": "^3.9.6"
   },
   "devDependencies": {
     "@magic/tsconfig": "workspace:*",


### PR DESCRIPTION
Replaces #233. Renovate got the bump right, it just can't do the reformat that comes with it: 3.9.6 wraps a union in `packages/modal/src/constants/types.ts` differently than 3.8.3 did, so Format fails on its branch.

```diff
-    | (({ hide }: { hide: HookHideFunction }) => void)
-    | undefined;
+    (({ hide }: { hide: HookHideFunction }) => void) | undefined;
```

Same type, and prettier is a devDependency, so the published package is unchanged.

`tools/prettier` also moves from `^3.5.3` to `^3.9.6`. Renovate's `pnpmDedupe` collapsed both workspaces onto one copy in the lockfile, but the declared floor left `packages/modal` on an exact 3.9.6 and `tools/prettier` free to resolve anything from 3.5.3 up. Under `nodeLinker: hoisted` a split there puts a second prettier in `node_modules` and the two `format` scripts start checking against different versions.

Stacked on #236, which has to land first for Lint to pass.

`doctor`, `typecheck`, `lint`, `test` and `format` all pass locally with the turbo cache forced off:

![local validation suite](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/gstj/pr-assets-dump/ci/prettier-396-validation-suite.png)
