### PR TITLE
feat(modal)!: move swipe-to-dismiss onto gesture-handler's usePanGesture

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -227,6 +227,11 @@ jobs:
       - name: 🧪 Run Maestro smoke flows
         working-directory: ${{ env.EXAMPLE_DIR }}
         run: |
+          # The four swipe-dismiss flows are deliberately not here yet. They
+          # assert on text, and on iOS 26 + RN 0.83 XCUITest sees the whole RN
+          # root as one opaque element, so no text or testID in the app is
+          # reachable. Same reason the two flows above are down to launch plus
+          # a screenshot. See .maestro/README.md.
           maestro test \
             .maestro/smoke-launch.yaml \
             .maestro/smoke-modal-open-close.yaml

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ Install the package:
 yarn add react-native-magic-modal
 ```
 
+Minimum peer versions:
+
+| Peer                           | Minimum |
+| ------------------------------ | ------- |
+| `react`                        | 18.0.0  |
+| `react-native`                 | 0.81.0  |
+| `react-native-gesture-handler` | 3.0.0   |
+| `react-native-reanimated`      | 4.0.0   |
+
+The gesture-handler floor is a hard one from `react-native-magic-modal` 8.0.0 on: swipe-to-dismiss is built on the `usePanGesture` hook, which only exists in 3.x. Stay on 7.x if you're pinned to gesture-handler 2.x.
+
+On Expo, that pin is worth checking. SDK 55 still asks for `react-native-gesture-handler@~2.30.0`, so `npx expo install` will pull 2.x and `npx expo-doctor` will flag 3.x as a major mismatch. Installing 3.x anyway works, and you can quiet the check by adding the package to `expo.install.exclude` in your `package.json`, the way `examples/kitchen-sink` does. Otherwise stay on `react-native-magic-modal` 7.x until Expo moves its pin.
+
 ## Quickstart
 
 Insert a `MagicModalPortal` at the top of your application structure, and a `GestureHandlerRootView` if you haven't already:
@@ -83,6 +96,8 @@ export default function App() {
 ```
 
 Tip: the root `_layout.tsx` is usually the best place to put it in a project using expo-router.
+
+The `GestureHandlerRootView` is required. The portal renders a `GestureDetector` for the swipe gesture, and gesture-handler 3.x throws when one renders without a root view above it. 2.x only logged a warning, so apps that skipped it got away with it.
 
 ## Examples
 
@@ -213,7 +228,9 @@ const UploadModal = ({ progress }) => (
 );
 
 const handleUpload = async (file) => {
-  const { modalID, update } = magicModal.show(() => <UploadModal progress={0} />);
+  const { modalID, update } = magicModal.show(() => (
+    <UploadModal progress={0} />
+  ));
 
   await uploadFile(file, {
     onProgress: (progress) => update(() => <UploadModal progress={progress} />),

--- a/examples/kitchen-sink/.maestro/README.md
+++ b/examples/kitchen-sink/.maestro/README.md
@@ -22,9 +22,44 @@ These flows only touch UI surfaces that exist on the `renovate-sweep` /
 | `crash-test-dropdown.yaml` | References `app/crash-test.tsx` ("Android Crash Test (Pure Reproduction)") which only exists on the issue-155 fix branch. |
 | `issue155-crash-test.yaml` | References `app/issue155.tsx` ("Test Issue #155 (Navigation Crash)") which only exists on the issue-155 fix branch.       |
 | `stress-test-crash.yaml`   | Same as above — depends on the crash-test screen.                                                                         |
+| `swipe-dismiss-up.yaml`    | Asserts on text. XCUITest can't see into the RN tree on this stack, see below.                                            |
+| `swipe-dismiss-down.yaml`  | Same.                                                                                                                     |
+| `swipe-dismiss-left.yaml`  | Same.                                                                                                                     |
+| `swipe-dismiss-right.yaml` | Same.                                                                                                                     |
 
 Once the issue-155 fix branch is merged (which adds the `crash-test` and
-`issue155` route files), add these flows to the `e2e-ios.yml` matrix.
+`issue155` route files), add those two flows to the `e2e-ios.yml` matrix.
+
+## The swipe flows
+
+The four `swipe-dismiss-*.yaml` flows drive the `Swipe To Dismiss` screen
+(`src/app/swipe.tsx`) instead of the home screen's "Show Modal", which
+randomizes its direction and closes itself on a timer. Each one opens a modal
+pinned to one direction, flicks it off screen, and asserts on the hide reason
+the screen renders for that direction. A backdrop tap or a stray `hide()`
+empties the screen just the same, so the reason is what separates a completed
+swipe from everything else.
+
+They don't run yet. On iOS 26 + RN 0.83, XCUITest reports the entire React
+Native root as a single opaque accessibility element with no children, so no
+text and no `testID` in the app is reachable. `maestro hierarchy` on the home
+screen returns one node at `[0,0][402,874]`. That's the same wall that reduced
+`smoke-launch.yaml` and `smoke-modal-open-close.yaml` to launch-plus-screenshot,
+and it applies to buttons that predate these flows: `assertVisible: "Show
+Modal"` fails too.
+
+The swipe coordinates are tuned and verified, so the flows should pass as
+written once the accessibility tree comes back. Each direction was confirmed by
+hand on an iPhone 17 Pro simulator (402x874 pt) by driving the same taps and
+swipes through coordinates and reading the rendered hide reason. The horizontal
+pair travels 70% of the screen width; 40% came out under
+`swipeVelocityThreshold` once Maestro's interpolation decelerated.
+
+Run one by hand:
+
+```sh
+maestro test examples/kitchen-sink/.maestro/swipe-dismiss-up.yaml
+```
 
 ## Run locally
 

--- a/examples/kitchen-sink/.maestro/swipe-dismiss-down.yaml
+++ b/examples/kitchen-sink/.maestro/swipe-dismiss-down.yaml
@@ -1,0 +1,44 @@
+appId: com.gstj.reactnativemagicmodalexample
+---
+# Swipe-to-dismiss, down.
+#
+# The flick travels along the modal's configured axis and has to clear
+# `swipeVelocityThreshold`, 500 pt/s by default. These coordinates were tuned
+# against an iPhone 17 Pro simulator: they land around 2000-3000 pt/s, over the
+# threshold without being so fast the simulator drops the gesture. The
+# horizontal pair travels 70% of the width because 40% came out under the
+# threshold once Maestro's interpolation decelerated. Both start on the modal
+# content, since the pan gesture sits on a `pointerEvents: box-none` wrapper.
+#
+# The assertion is on the hide reason the screen reports for this direction,
+# rather than on the modal disappearing. A backdrop tap or a stray `hide()`
+# empties the screen too, and only a completed swipe reports SWIPE_COMPLETE.
+# gesture-handler has more than one "the gesture ended" callback and picking the
+# wrong one still looks correct by eye, so the reason is the part worth
+# asserting on.
+- launchApp:
+    clearState: true
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element: "Swipe To Dismiss"
+    direction: DOWN
+- tapOn: "Swipe To Dismiss"
+- extendedWaitUntil:
+    visible: "Swipe down"
+    timeout: 10000
+- tapOn: "Swipe down"
+- extendedWaitUntil:
+    visible: "Example Modal"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 5000
+- swipe:
+    start: 50%, 45%
+    end: 50%, 95%
+    duration: 150
+- extendedWaitUntil:
+    visible: "down: SWIPE_COMPLETE"
+    timeout: 10000
+- assertNotVisible: "Example Modal"
+- takeScreenshot: swipe-dismiss-down

--- a/examples/kitchen-sink/.maestro/swipe-dismiss-left.yaml
+++ b/examples/kitchen-sink/.maestro/swipe-dismiss-left.yaml
@@ -1,0 +1,44 @@
+appId: com.gstj.reactnativemagicmodalexample
+---
+# Swipe-to-dismiss, left.
+#
+# The flick travels along the modal's configured axis and has to clear
+# `swipeVelocityThreshold`, 500 pt/s by default. These coordinates were tuned
+# against an iPhone 17 Pro simulator: they land around 2000-3000 pt/s, over the
+# threshold without being so fast the simulator drops the gesture. The
+# horizontal pair travels 70% of the width because 40% came out under the
+# threshold once Maestro's interpolation decelerated. Both start on the modal
+# content, since the pan gesture sits on a `pointerEvents: box-none` wrapper.
+#
+# The assertion is on the hide reason the screen reports for this direction,
+# rather than on the modal disappearing. A backdrop tap or a stray `hide()`
+# empties the screen too, and only a completed swipe reports SWIPE_COMPLETE.
+# gesture-handler has more than one "the gesture ended" callback and picking the
+# wrong one still looks correct by eye, so the reason is the part worth
+# asserting on.
+- launchApp:
+    clearState: true
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element: "Swipe To Dismiss"
+    direction: DOWN
+- tapOn: "Swipe To Dismiss"
+- extendedWaitUntil:
+    visible: "Swipe left"
+    timeout: 10000
+- tapOn: "Swipe left"
+- extendedWaitUntil:
+    visible: "Example Modal"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 5000
+- swipe:
+    start: 85%, 50%
+    end: 15%, 50%
+    duration: 150
+- extendedWaitUntil:
+    visible: "left: SWIPE_COMPLETE"
+    timeout: 10000
+- assertNotVisible: "Example Modal"
+- takeScreenshot: swipe-dismiss-left

--- a/examples/kitchen-sink/.maestro/swipe-dismiss-right.yaml
+++ b/examples/kitchen-sink/.maestro/swipe-dismiss-right.yaml
@@ -1,0 +1,44 @@
+appId: com.gstj.reactnativemagicmodalexample
+---
+# Swipe-to-dismiss, right.
+#
+# The flick travels along the modal's configured axis and has to clear
+# `swipeVelocityThreshold`, 500 pt/s by default. These coordinates were tuned
+# against an iPhone 17 Pro simulator: they land around 2000-3000 pt/s, over the
+# threshold without being so fast the simulator drops the gesture. The
+# horizontal pair travels 70% of the width because 40% came out under the
+# threshold once Maestro's interpolation decelerated. Both start on the modal
+# content, since the pan gesture sits on a `pointerEvents: box-none` wrapper.
+#
+# The assertion is on the hide reason the screen reports for this direction,
+# rather than on the modal disappearing. A backdrop tap or a stray `hide()`
+# empties the screen too, and only a completed swipe reports SWIPE_COMPLETE.
+# gesture-handler has more than one "the gesture ended" callback and picking the
+# wrong one still looks correct by eye, so the reason is the part worth
+# asserting on.
+- launchApp:
+    clearState: true
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element: "Swipe To Dismiss"
+    direction: DOWN
+- tapOn: "Swipe To Dismiss"
+- extendedWaitUntil:
+    visible: "Swipe right"
+    timeout: 10000
+- tapOn: "Swipe right"
+- extendedWaitUntil:
+    visible: "Example Modal"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 5000
+- swipe:
+    start: 15%, 50%
+    end: 85%, 50%
+    duration: 150
+- extendedWaitUntil:
+    visible: "right: SWIPE_COMPLETE"
+    timeout: 10000
+- assertNotVisible: "Example Modal"
+- takeScreenshot: swipe-dismiss-right

--- a/examples/kitchen-sink/.maestro/swipe-dismiss-up.yaml
+++ b/examples/kitchen-sink/.maestro/swipe-dismiss-up.yaml
@@ -1,0 +1,44 @@
+appId: com.gstj.reactnativemagicmodalexample
+---
+# Swipe-to-dismiss, up.
+#
+# The flick travels along the modal's configured axis and has to clear
+# `swipeVelocityThreshold`, 500 pt/s by default. These coordinates were tuned
+# against an iPhone 17 Pro simulator: they land around 2000-3000 pt/s, over the
+# threshold without being so fast the simulator drops the gesture. The
+# horizontal pair travels 70% of the width because 40% came out under the
+# threshold once Maestro's interpolation decelerated. Both start on the modal
+# content, since the pan gesture sits on a `pointerEvents: box-none` wrapper.
+#
+# The assertion is on the hide reason the screen reports for this direction,
+# rather than on the modal disappearing. A backdrop tap or a stray `hide()`
+# empties the screen too, and only a completed swipe reports SWIPE_COMPLETE.
+# gesture-handler has more than one "the gesture ended" callback and picking the
+# wrong one still looks correct by eye, so the reason is the part worth
+# asserting on.
+- launchApp:
+    clearState: true
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element: "Swipe To Dismiss"
+    direction: DOWN
+- tapOn: "Swipe To Dismiss"
+- extendedWaitUntil:
+    visible: "Swipe up"
+    timeout: 10000
+- tapOn: "Swipe up"
+- extendedWaitUntil:
+    visible: "Example Modal"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 5000
+- swipe:
+    start: 50%, 55%
+    end: 50%, 8%
+    duration: 150
+- extendedWaitUntil:
+    visible: "up: SWIPE_COMPLETE"
+    timeout: 10000
+- assertNotVisible: "Example Modal"
+- takeScreenshot: swipe-dismiss-up

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -26,7 +26,8 @@
     },
     "install": {
       "exclude": [
-        "react-native-reanimated"
+        "react-native-reanimated",
+        "react-native-gesture-handler"
       ]
     }
   },
@@ -41,7 +42,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
-    "react-native-gesture-handler": "~2.30.0",
+    "react-native-gesture-handler": "~3.1.0",
     "react-native-magic-modal": "workspace:*",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.6.2",

--- a/examples/kitchen-sink/src/app/_layout.tsx
+++ b/examples/kitchen-sink/src/app/_layout.tsx
@@ -8,6 +8,7 @@ const App = () => {
     <GestureHandlerRootView>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="index" />
+        <Stack.Screen name="swipe" />
         <Stack.Screen
           name="modal"
           options={{

--- a/examples/kitchen-sink/src/app/index.tsx
+++ b/examples/kitchen-sink/src/app/index.tsx
@@ -157,6 +157,18 @@ export default () => {
       <Pressable style={styles.button} onPress={showToast}>
         <Text style={styles.buttonText}>Show Toast</Text>
       </Pressable>
+      <Pressable
+        testID="swipe-tests-button"
+        accessibilityRole="button"
+        accessibilityLabel="Swipe To Dismiss"
+        accessible
+        style={styles.button}
+        onPress={() => {
+          router.push("/swipe");
+        }}
+      >
+        <Text style={styles.buttonText}>Swipe To Dismiss</Text>
+      </Pressable>
       {Platform.OS === "ios" && (
         <>
           <Pressable

--- a/examples/kitchen-sink/src/app/swipe.tsx
+++ b/examples/kitchen-sink/src/app/swipe.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable react-native/no-color-literals */
+import type { Direction } from "react-native-magic-modal";
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { magicModal, MagicModalHideReason } from "react-native-magic-modal";
+
+import { ExampleModal } from "@/components/ExampleModal";
+
+const directions = ["up", "down", "left", "right"] as const;
+
+const initialReasons = {
+  up: "none",
+  down: "none",
+  left: "none",
+  right: "none",
+} satisfies Record<Direction, string>;
+
+/**
+ * Swipe-to-dismiss harness. The home screen's "Show Modal" picks a random
+ * direction and closes itself on a timer, which is fine for a demo and useless
+ * for a test. Each button here opens a modal pinned to one direction and leaves
+ * it open until something dismisses it.
+ *
+ * The hide reason is rendered per direction rather than as a single "last
+ * reason" line. A Maestro flow can then assert that the modal it opened is the
+ * one that got dismissed, and one screenshot covers all four directions.
+ */
+export default () => {
+  const [reasons, setReasons] =
+    React.useState<Record<Direction, string>>(initialReasons);
+
+  const showSwipeModal = async (swipeDirection: Direction) => {
+    setReasons((previous) => ({ ...previous, [swipeDirection]: "pending" }));
+
+    const result = await magicModal.show(() => <ExampleModal />, {
+      swipeDirection,
+    }).promise;
+
+    setReasons((previous) => ({
+      ...previous,
+      [swipeDirection]: result.reason,
+    }));
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Swipe To Dismiss</Text>
+      {directions.map((direction) => (
+        <Pressable
+          key={direction}
+          testID={`swipe-${direction}-button`}
+          accessibilityRole="button"
+          accessibilityLabel={`Swipe ${direction}`}
+          accessible
+          style={styles.button}
+          onPress={() => {
+            void showSwipeModal(direction);
+          }}
+        >
+          <Text style={styles.buttonText}>Swipe {direction}</Text>
+        </Pressable>
+      ))}
+      <View style={styles.results}>
+        {directions.map((direction) => (
+          <Text key={direction} testID={`swipe-${direction}-reason`} accessible>
+            {`${direction}: ${reasons[direction]}`}
+          </Text>
+        ))}
+      </View>
+      <Text style={styles.legend}>
+        {`A completed swipe reports ${MagicModalHideReason.SWIPE_COMPLETE}.`}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 16,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: "bold",
+  },
+  button: {
+    height: 40,
+    paddingHorizontal: 20,
+    backgroundColor: "#000000",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 5,
+  },
+  buttonText: {
+    color: "#ffffff",
+    fontWeight: "bold",
+  },
+  results: {
+    alignItems: "center",
+    gap: 2,
+  },
+  legend: {
+    fontSize: 12,
+    color: "#666666",
+  },
+});

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.81.0",
-    "react-native-gesture-handler": ">=2.20.0",
+    "react-native-gesture-handler": ">=3.0.0",
     "react-native-reanimated": ">=4.0.0",
     "react-native-worklets": ">=0.5.0"
   },

--- a/packages/modal/src/components/MagicModal.swipe.test.tsx
+++ b/packages/modal/src/components/MagicModal.swipe.test.tsx
@@ -1,0 +1,250 @@
+import type { PanGestureConfig } from "react-native-gesture-handler";
+import React from "react";
+import { Text } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { act, render as rntlRender } from "@testing-library/react-native";
+
+import type { Direction } from "../constants/types";
+import { MagicModalHideReason } from "../constants/types";
+import { magicModal } from "../utils/magicModalHandler";
+import { MagicModalPortal } from "./MagicModalPortal/MagicModalPortal";
+
+/**
+ * The swipe gesture is the one part of the modal the public API can't drive:
+ * it lives inside a gesture-handler hook and its callbacks are worklets. So we
+ * intercept the config `MagicModal` hands to `usePanGesture` and call the
+ * callbacks ourselves.
+ *
+ * The point of these tests is the callback *names*. gesture-handler 3.x has
+ * both `onDeactivate` (what `.onEnd` used to be) and `onFinalize`, and
+ * `onFinalize` additionally runs for gestures that never activated. Wiring the
+ * dismissal to the wrong one leaves the modal looking correct in a manual test
+ * while `SWIPE_COMPLETE` resolves at a different point in the gesture
+ * lifecycle.
+ */
+jest.mock("react-native-gesture-handler", () => {
+  const actual = jest.requireActual<Record<string, unknown>>(
+    "react-native-gesture-handler",
+  );
+
+  const capturedPanConfigs: PanGestureConfig[] = [];
+
+  return {
+    ...actual,
+    capturedPanConfigs,
+    usePanGesture: (config: PanGestureConfig) => {
+      capturedPanConfigs.push(config);
+      return { handlerTag: -1 };
+    },
+    GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+const { capturedPanConfigs } = jest.requireMock<{
+  capturedPanConfigs: PanGestureConfig[];
+}>("react-native-gesture-handler");
+
+const content = "Taveira";
+
+const ModalContent = () => <Text testID="swipe-content">{content}</Text>;
+
+/** The most recent config handed to `usePanGesture`, i.e. the live one. */
+const latestPanConfig = () => {
+  const config = capturedPanConfigs.at(-1);
+
+  if (!config) {
+    throw new Error("MagicModal never called usePanGesture");
+  }
+
+  return config;
+};
+
+const showModal = (swipeDirection: Direction | undefined) => {
+  rntlRender(
+    <GestureHandlerRootView>
+      <MagicModalPortal />
+    </GestureHandlerRootView>,
+  );
+
+  let promise: Promise<unknown> | undefined;
+
+  act(() => {
+    promise = magicModal.show(() => <ModalContent />, {
+      swipeDirection,
+    }).promise;
+  });
+
+  return promise;
+};
+
+const baseEvent = {
+  handlerTag: -1,
+  numberOfPointers: 1,
+  pointerType: 0,
+  x: 0,
+  y: 0,
+  absoluteX: 0,
+  absoluteY: 0,
+  stylusData: undefined,
+  translationX: 0,
+  translationY: 0,
+  changeX: 0,
+  changeY: 0,
+  velocityX: 0,
+  velocityY: 0,
+};
+
+type ActiveEvent = Parameters<NonNullable<PanGestureConfig["onActivate"]>>[0];
+type UpdateEvent = Parameters<
+  Extract<NonNullable<PanGestureConfig["onUpdate"]>, (event: never) => void>
+>[0];
+type EndEvent = Parameters<NonNullable<PanGestureConfig["onDeactivate"]>>[0];
+
+const activeEvent = () => baseEvent as unknown as ActiveEvent;
+
+const endEvent = (velocity: { velocityX: number; velocityY: number }) =>
+  ({ ...baseEvent, ...velocity, canceled: false }) as unknown as EndEvent;
+
+/**
+ * `onUpdate` is typed as the callback union'd with `Animated.event`, which
+ * isn't callable. We only ever pass the callback form.
+ */
+const runOnUpdate = (
+  config: PanGestureConfig,
+  translation: { translationX: number; translationY: number },
+) => {
+  const onUpdate = config.onUpdate as
+    | ((event: UpdateEvent) => void)
+    | undefined;
+
+  onUpdate?.({ ...baseEvent, ...translation } as unknown as UpdateEvent);
+};
+
+const fastVelocity = {
+  up: { velocityX: 0, velocityY: -900 },
+  down: { velocityX: 0, velocityY: 900 },
+  left: { velocityX: -900, velocityY: 0 },
+  right: { velocityX: 900, velocityY: 0 },
+} satisfies Record<Direction, { velocityX: number; velocityY: number }>;
+
+const directions = ["up", "down", "left", "right"] as const;
+
+beforeEach(() => {
+  // No `hideAll` here. The testing library unmounts the portal between tests
+  // already, and hiding into an unmounted tree makes React warn about updates
+  // outside `act`.
+  capturedPanConfigs.length = 0;
+});
+
+describe("MagicModal swipe gesture", () => {
+  it("hangs the dismissal off onDeactivate and leaves onFinalize alone", () => {
+    showModal("down");
+
+    const config = latestPanConfig();
+
+    expect(typeof config.onActivate).toBe("function");
+    expect(typeof config.onUpdate).toBe("function");
+    expect(typeof config.onDeactivate).toBe("function");
+
+    // `onFinalize` also runs for gestures that never activated: a tap that
+    // failed the slop check, or a cancelled gesture. Anything hung off it
+    // would run the dismissal on paths `.onEnd` never fired on.
+    expect(config.onFinalize).toBeUndefined();
+    expect(config.onBegin).toBeUndefined();
+  });
+
+  it("keeps the callbacks on the UI thread", () => {
+    showModal("down");
+
+    const config = latestPanConfig();
+
+    // gesture-handler picks between the reanimated and the JS detector by
+    // looking for `__workletHash` on the callbacks. Dropping the "worklet"
+    // directives would silently move the whole swipe onto the JS thread.
+    for (const name of ["onActivate", "onUpdate", "onDeactivate"] as const) {
+      expect(config[name]).toHaveProperty("__workletHash");
+    }
+  });
+
+  it("only enables the gesture when a swipeDirection is set", () => {
+    showModal("down");
+    expect(latestPanConfig().enabled).toBe(true);
+
+    capturedPanConfigs.length = 0;
+    showModal(undefined);
+    expect(latestPanConfig().enabled).toBe(false);
+  });
+
+  it("keeps the same config object across re-renders", () => {
+    showModal("down");
+
+    const first = latestPanConfig();
+    const seen = capturedPanConfigs.length;
+
+    act(() => {
+      magicModal.show(() => <ModalContent />, { swipeDirection: "down" });
+    });
+
+    // The first modal re-renders when a second one is pushed. Its config has
+    // to keep its identity: `usePanGesture` memoizes on it and re-pushes the
+    // whole config to the native side whenever it changes.
+    expect(capturedPanConfigs.length).toBeGreaterThan(seen);
+    expect(capturedPanConfigs[0]).toBe(first);
+  });
+
+  it.each(directions)(
+    "resolves with SWIPE_COMPLETE when the %s swipe clears the velocity threshold",
+    async (swipeDirection) => {
+      const promise = showModal(swipeDirection);
+      const config = latestPanConfig();
+
+      let result: unknown;
+      void promise?.then((value) => {
+        result = value;
+      });
+
+      await act(async () => {
+        config.onActivate?.(activeEvent());
+        config.onDeactivate?.(endEvent(fastVelocity[swipeDirection]));
+
+        // The dismissal spring runs for several frames and its completion
+        // callback hops from the UI thread back to JS via `scheduleOnRN`, so
+        // `hide` lands well after `onDeactivate` returns. Poll on timers, which
+        // is what drives the spring; awaiting the show promise in here instead
+        // deadlocks, because the frame loop doesn't advance inside `act`.
+        for (let i = 0; i < 100 && result === undefined; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+      });
+
+      expect(result).toEqual({
+        reason: MagicModalHideReason.SWIPE_COMPLETE,
+      });
+    },
+  );
+
+  it.each(directions)(
+    "keeps the %s modal open when the swipe is under the velocity threshold",
+    async (swipeDirection) => {
+      const promise = showModal(swipeDirection);
+      const config = latestPanConfig();
+
+      let resolved = false;
+      void promise?.then(() => {
+        resolved = true;
+      });
+
+      act(() => {
+        config.onActivate?.(activeEvent());
+        runOnUpdate(config, { translationX: 5, translationY: 5 });
+        config.onDeactivate?.(endEvent({ velocityX: 10, velocityY: 10 }));
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(resolved).toBe(false);
+    },
+  );
+});

--- a/packages/modal/src/components/MagicModal.tsx
+++ b/packages/modal/src/components/MagicModal.tsx
@@ -1,6 +1,7 @@
+import type { PanGestureConfig } from "react-native-gesture-handler";
 import React, { memo, useMemo } from "react";
 import { Pressable, StyleSheet, useWindowDimensions, View } from "react-native";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { GestureDetector, usePanGesture } from "react-native-gesture-handler";
 import Animated, {
   Extrapolation,
   FadeIn,
@@ -92,104 +93,137 @@ export const MagicModal = memo(
       [height, width],
     );
 
-    const pan = Gesture.Pan()
-      .enabled(!!config.swipeDirection)
-      // Matches the platform touch slop. Anything smaller (we used to use 1)
-      // lets finger jitter during a tap activate the pan, which cancels the
-      // touch on whatever the user was actually pressing inside the modal.
-      .minDistance(TOUCH_SLOP)
-      .onStart(() => {
-        "worklet";
+    /**
+     * `usePanGesture` memoizes on the identity of the config object it is
+     * handed, and re-pushes the whole config to the native side whenever that
+     * identity changes. Building the object inline would do that on every
+     * render, so it lives in a `useMemo` keyed on everything the worklets
+     * close over.
+     *
+     * The callback names are gesture-handler v3's. The v2 builder equivalents
+     * were `.onStart` (`onActivate`), `.onUpdate` (`onUpdate`) and `.onEnd`
+     * (`onDeactivate`). `onDeactivate` is deliberate: it is the callback wired
+     * to `CALLBACK_TYPE.END`, which is what `.onEnd` registered, so
+     * `SWIPE_COMPLETE` still resolves at the same point in the gesture
+     * lifecycle. `onFinalize` (`CALLBACK_TYPE.FINALIZE`) also runs after
+     * gestures that never activated, and using it here would fire the
+     * dismissal spring on taps that failed the slop check.
+     */
+    const panConfig = useMemo<PanGestureConfig>(
+      () => ({
+        enabled: !!config.swipeDirection,
+        // Matches the platform touch slop. Anything smaller (we used to use 1)
+        // lets finger jitter during a tap activate the pan, which cancels the
+        // touch on whatever the user was actually pressing inside the modal.
+        minDistance: TOUCH_SLOP,
+        onActivate: () => {
+          "worklet";
 
-        prevTranslationX.value = translationX.value;
-        prevTranslationY.value = translationY.value;
-      })
-      .onUpdate((event) => {
-        "worklet";
+          prevTranslationX.value = translationX.value;
+          prevTranslationY.value = translationY.value;
+        },
+        onUpdate: (event) => {
+          "worklet";
 
-        const translationValue = isHorizontal
-          ? event.translationX
-          : event.translationY;
+          const translationValue = isHorizontal
+            ? event.translationX
+            : event.translationY;
 
-        const prevTranslationValue = isHorizontal
-          ? prevTranslationX.value
-          : prevTranslationY.value;
+          const prevTranslationValue = isHorizontal
+            ? prevTranslationX.value
+            : prevTranslationY.value;
 
-        const shouldDampMap = {
-          up: translationValue > 0,
-          down: translationValue < 0,
-          left: translationValue > 0,
-          right: translationValue < 0,
-        } satisfies Record<Direction, boolean>;
+          const shouldDampMap = {
+            up: translationValue > 0,
+            down: translationValue < 0,
+            left: translationValue > 0,
+            right: translationValue < 0,
+          } satisfies Record<Direction, boolean>;
 
-        const shouldDamp =
-          shouldDampMap[config.swipeDirection ?? defaultDirection];
+          const shouldDamp =
+            shouldDampMap[config.swipeDirection ?? defaultDirection];
 
-        const dampedTranslation = shouldDamp
-          ? prevTranslationValue + translationValue * config.dampingFactor
-          : prevTranslationValue + translationValue;
+          const dampedTranslation = shouldDamp
+            ? prevTranslationValue + translationValue * config.dampingFactor
+            : prevTranslationValue + translationValue;
 
-        if (isHorizontal) {
-          translationX.value = dampedTranslation;
-        } else {
-          translationY.value = dampedTranslation;
-        }
-      })
-      .onEnd((event) => {
-        "worklet";
+          if (isHorizontal) {
+            translationX.value = dampedTranslation;
+          } else {
+            translationY.value = dampedTranslation;
+          }
+        },
+        onDeactivate: (event) => {
+          "worklet";
 
-        const velocityThreshold = config.swipeVelocityThreshold;
+          const velocityThreshold = config.swipeVelocityThreshold;
 
-        const shouldHideMap = {
-          up: event.velocityY < -velocityThreshold,
-          down: event.velocityY > velocityThreshold,
-          right: event.velocityX > velocityThreshold,
-          left: event.velocityX < -velocityThreshold,
-        } satisfies Record<Direction, boolean>;
+          const shouldHideMap = {
+            up: event.velocityY < -velocityThreshold,
+            down: event.velocityY > velocityThreshold,
+            right: event.velocityX > velocityThreshold,
+            left: event.velocityX < -velocityThreshold,
+          } satisfies Record<Direction, boolean>;
 
-        const shouldHide =
-          shouldHideMap[config.swipeDirection ?? defaultDirection];
+          const shouldHide =
+            shouldHideMap[config.swipeDirection ?? defaultDirection];
 
-        if (!shouldHide) {
-          translationX.value = withSpring(0, {
-            velocity: event.velocityX,
-            damping: 75,
-          });
-          translationY.value = withSpring(0, {
-            velocity: event.velocityY,
-            damping: 75,
-          });
-          return;
-        }
-
-        const mainTranslation = isHorizontal ? translationX : translationY;
-
-        mainTranslation.value = withSpring(
-          rangeMap[config.swipeDirection ?? defaultDirection],
-          { velocity: event.velocityX, overshootClamping: true },
-          (success) => {
-            "worklet";
-            if (!success) return;
-
-            // TODO: Re-enable after figuring out the Platform.OS
-            // usage inside a worklet.
-            // if (Platform.OS !== "web") {
-            scheduleOnRN(hide, {
-              reason: MagicModalHideReason.SWIPE_COMPLETE,
+          if (!shouldHide) {
+            translationX.value = withSpring(0, {
+              velocity: event.velocityX,
+              damping: 75,
             });
-            //   return;
-            // }
+            translationY.value = withSpring(0, {
+              velocity: event.velocityY,
+              damping: 75,
+            });
+            return;
+          }
 
-            // runOnJS(setIsSwipeComplete)(true);
+          const mainTranslation = isHorizontal ? translationX : translationY;
 
-            // // Set immediate is needed so the hide function is called
-            // // after "isSwipeComplete" is set to true.
-            // runOnJS(setImmediate)(() =>
-            //   hide({ reason: MagicModalHideReason.SWIPE_COMPLETE }),
-            // );
-          },
-        );
-      });
+          mainTranslation.value = withSpring(
+            rangeMap[config.swipeDirection ?? defaultDirection],
+            { velocity: event.velocityX, overshootClamping: true },
+            (success) => {
+              "worklet";
+              if (!success) return;
+
+              // TODO: Re-enable after figuring out the Platform.OS
+              // usage inside a worklet.
+              // if (Platform.OS !== "web") {
+              scheduleOnRN(hide, {
+                reason: MagicModalHideReason.SWIPE_COMPLETE,
+              });
+              //   return;
+              // }
+
+              // runOnJS(setIsSwipeComplete)(true);
+
+              // // Set immediate is needed so the hide function is called
+              // // after "isSwipeComplete" is set to true.
+              // runOnJS(setImmediate)(() =>
+              //   hide({ reason: MagicModalHideReason.SWIPE_COMPLETE }),
+              // );
+            },
+          );
+        },
+      }),
+      [
+        config.dampingFactor,
+        config.swipeDirection,
+        config.swipeVelocityThreshold,
+        hide,
+        isHorizontal,
+        prevTranslationX,
+        prevTranslationY,
+        rangeMap,
+        translationX,
+        translationY,
+      ],
+    );
+
+    const pan = usePanGesture(panConfig);
 
     const animatedStyles = useAnimatedStyle(() => {
       "worklet";

--- a/packages/modal/src/components/MagicModalPortal/MagicModalPortal.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/MagicModalPortal.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { Text } from "react-native";
-import { act, fireEvent, render, screen } from "@testing-library/react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import {
+  act,
+  fireEvent,
+  render as rntlRender,
+  screen,
+} from "@testing-library/react-native";
 
 import { MagicModalHideReason } from "../../constants/types";
 import { magicModal } from "../../utils/magicModalHandler";
@@ -11,6 +17,15 @@ const content = "Taveira";
 const ModalContent = ({ testID }: { testID: string }) => (
   <Text testID={testID}>{content}</Text>
 );
+
+/**
+ * gesture-handler 3.x throws from `GestureDetector` when there is no
+ * `GestureHandlerRootView` above it, where 2.x only warned. The portal renders
+ * a `GestureDetector` for the swipe gesture, so every render here needs the
+ * root view, same as in a real app.
+ */
+const render = (ui: React.ReactElement) =>
+  rntlRender(<GestureHandlerRootView>{ui}</GestureHandlerRootView>);
 
 describe("MagicModalPortal", () => {
   it("renders children only after show is called", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 55.0.16(expo@55.0.28)(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       expo-router:
         specifier: ~55.0.17
-        version: 55.0.17(b0198fa7b7a80ad6abd3cb4cfdc0492c)
+        version: 55.0.17(67b1bfbcd89eaf164612bfc181ae32c2)
       expo-splash-screen:
         specifier: ~55.0.23
         version: 55.0.23(expo@55.0.28)(typescript@5.9.3)
@@ -61,8 +61,8 @@ importers:
         specifier: 0.83.6
         version: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0)
       react-native-gesture-handler:
-        specifier: ~2.30.0
-        version: 2.30.1(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
+        specifier: ~3.1.0
+        version: 3.1.0(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       react-native-magic-modal:
         specifier: workspace:*
         version: link:../../packages/modal
@@ -174,8 +174,8 @@ importers:
         specifier: '>=18.0.0'
         version: 19.2.0
       react-native-gesture-handler:
-        specifier: '>=2.20.0'
-        version: 2.30.1(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
+        specifier: '>=3.0.0'
+        version: 3.1.0(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       react-native-reanimated:
         specifier: '>=4.0.0'
         version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
@@ -828,10 +828,6 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
-
-  '@egjs/hammerjs@2.0.17':
-    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
-    engines: {node: '>=0.8.0'}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -2358,9 +2354,6 @@ packages:
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
-  '@types/hammerjs@2.0.46':
-    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
-
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
@@ -2394,6 +2387,9 @@ packages:
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
+
+  '@types/react-test-renderer@19.1.0':
+    resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
@@ -4307,9 +4303,6 @@ packages:
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
 
-  hoist-non-react-statics@3.3.2:
-    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
-
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
@@ -5827,8 +5820,8 @@ packages:
   react-is@19.2.8:
     resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
 
-  react-native-gesture-handler@2.30.1:
-    resolution: {integrity: sha512-xIUBDo5ktmJs++0fZlavQNvDEE4PsihWhSeJsJtoz4Q6p0MiTM9TgrTgfEgzRR36qGPytFoeq+ShLrVwGdpUdA==}
+  react-native-gesture-handler@3.1.0:
+    resolution: {integrity: sha512-+kWVyZ6vLdtyFa1/aOc/sZncLAVPUKxhji/ttbiLI7hOaSU44bLjhI7p+Ns+pMl2r3RqPXssl5qHReYet9G77g==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -7751,10 +7744,6 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@egjs/hammerjs@2.0.17':
-    dependencies:
-      '@types/hammerjs': 2.0.46
-
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.5(jiti@2.7.0)
@@ -7870,7 +7859,7 @@ snapshots:
       ws: 8.21.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.17(b0198fa7b7a80ad6abd3cb4cfdc0492c)
+      expo-router: 55.0.17(67b1bfbcd89eaf164612bfc181ae32c2)
       react-native: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -8143,7 +8132,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.28)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.17(b0198fa7b7a80ad6abd3cb4cfdc0492c)
+      expo-router: 55.0.17(67b1bfbcd89eaf164612bfc181ae32c2)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -9575,8 +9564,6 @@ snapshots:
     dependencies:
       '@types/node': 26.1.1
 
-  '@types/hammerjs@2.0.46': {}
-
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
@@ -9615,6 +9602,10 @@ snapshots:
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
+
+  '@types/react-test-renderer@19.1.0':
+    dependencies:
+      '@types/react': 19.2.17
 
   '@types/react@19.2.17':
     dependencies:
@@ -11406,7 +11397,7 @@ snapshots:
     optionalDependencies:
       react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
 
-  expo-router@55.0.17(b0198fa7b7a80ad6abd3cb4cfdc0492c):
+  expo-router@55.0.17(67b1bfbcd89eaf164612bfc181ae32c2):
     dependencies:
       '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.28)(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.28)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
@@ -11445,7 +11436,7 @@ snapshots:
     optionalDependencies:
       '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react-test-renderer@19.2.6(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
-      react-native-gesture-handler: 2.30.1(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
+      react-native-gesture-handler: 3.1.0(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       react-native-web: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
@@ -11908,10 +11899,6 @@ snapshots:
   hermes-parser@0.35.0:
     dependencies:
       hermes-estree: 0.35.0
-
-  hoist-non-react-statics@3.3.2:
-    dependencies:
-      react-is: 16.13.1
 
   homedir-polyfill@1.0.3:
     dependencies:
@@ -13746,10 +13733,9 @@ snapshots:
 
   react-is@19.2.8: {}
 
-  react-native-gesture-handler@2.30.1(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0):
+  react-native-gesture-handler@3.1.0(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@egjs/hammerjs': 2.0.17
-      hoist-non-react-statics: 3.3.2
+      '@types/react-test-renderer': 19.1.0
       invariant: 2.2.4
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0)


### PR DESCRIPTION
Closes #221.

`Gesture.Pan()` is deprecated in gesture-handler 3.x, and `magic-eslint-config` extends `tseslint.configs.strictTypeChecked`, so `@typescript-eslint/no-deprecated` is an error. Installing 3.1.0 on `main` gives two lint errors, both in `MagicModal.tsx` (`Gesture` and `Gesture.Pan()`), and nothing else in the repo. This branch clears both.

## Migration

The builder chain becomes one config object handed to `usePanGesture`:

| v2 | v3 |
| --- | --- |
| `.enabled(x)` | `enabled: x` |
| `.minDistance(x)` | `minDistance: x` |
| `.onStart(fn)` | `onActivate: fn` |
| `.onUpdate(fn)` | `onUpdate: fn` |
| `.onEnd(fn)` | `onDeactivate: fn` |

The event objects keep their shape, so the three callback bodies port over untouched: `GestureEvent<PanExtendedHandlerData>` flattens `translationX`, `velocityY` and the rest onto the event the way the v2 payload did.

`.onEnd` maps to `onDeactivate`. In `gesture.ts`, `.onEnd` registers `CALLBACK_TYPE.END`. In `v3/hooks/utils/eventHandlersUtils.ts`, the dispatch switch resolves `CALLBACK_TYPE.END` to `onDeactivate` and `CALLBACK_TYPE.FINALIZE` to `onFinalize`. `onFinalize` also runs for gestures that never activated, so hanging the dismissal there would fire the spring on taps that failed the 10pt slop check, and `SWIPE_COMPLETE` would resolve on paths `.onEnd` never fired on.

`MagicModal.swipe.test.tsx` pins that down. It intercepts the config `MagicModal` hands to `usePanGesture` and drives the callbacks directly, asserting that `onFinalize` and `onBegin` stay unset, that all three callbacks keep their `__workletHash` (gesture-handler picks the reanimated detector over the JS one by looking for it), and that a flick over `swipeVelocityThreshold` resolves `SWIPE_COMPLETE` in each direction. Renaming `onDeactivate` to `onFinalize` in the source fails 6 of the 20 tests. Renaming `onActivate` to `onBegin` fails 2.

The config also moves into a `useMemo`. `usePanGesture` memoizes on the identity of the object it's handed and re-pushes the whole config to the native side when that changes, so an inline object would do it every render.

## Breaking changes

The peer bump is the one #221 called out. `usePanGesture` only exists in 3.x, so `react-native-gesture-handler` moves from `>=2.20.0` to `>=3.0.0` and this needs a major.

The second one isn't in the issue and consumers will hit it. 3.x's `GestureDetector` calls `useEnsureGestureHandlerRootView`, which throws in `__DEV__` when there's no `GestureHandlerRootView` above it. 2.x had no such check. The portal always renders a `GestureDetector`, so an app that skipped the root view and got away with it will now crash in development. It broke this repo's own suite too: all 8 `MagicModalPortal` tests fail on 3.1.0 before any of my changes, purely from the version bump. They now render inside a `GestureHandlerRootView`. Both changes are in the README and in the `BREAKING CHANGE:` footer.

Expo SDK 55 still pins `react-native-gesture-handler` to `~2.30.0`, so `npx expo install` pulls 2.x and `expo-doctor` reports 3.x as a major mismatch. Installing 3.x anyway works. The kitchen-sink adds the package to `expo.install.exclude` and the README tells consumers the same, with `react-native-magic-modal` 7.x as the fallback until Expo moves its pin.

The issue says `usePanGesture` ships only under the `v3/` entry point. It's re-exported from the package root as well, `src/index.ts:152` does `export * from './v3'`, so `react-native-gesture-handler/v3` isn't needed in the import. The peer floor is the same either way.

## Maestro

Four new flows, one per direction. They drive a new `Swipe To Dismiss` screen rather than the home screen's "Show Modal", which randomizes its direction and closes itself on a timer. Each opens a modal pinned to one direction, flicks it off screen, and asserts on the hide reason the screen renders. Asserting that the modal disappeared would pass for a backdrop tap too.

They're not in the CI matrix. Adding them would turn the E2E job red on every PR. On iOS 26 + RN 0.83, XCUITest reports the whole React Native root as one opaque accessibility element with no children: `maestro hierarchy` on the home screen returns a single node at `[0,0][402,874]`. No text and no `testID` are reachable, including on buttons that predate this branch, so `assertVisible: "Show Modal"` fails too. The same limitation is what reduced the two smoke flows to launch-plus-screenshot before I got here. The coordinates in the flows are tuned and verified, so they should pass as written once the tree comes back. `.maestro/README.md` has the detail.

## Proof

Release build on an iPhone 17 Pro simulator (iOS 26.5) with gesture-handler 3.1.0, driven through Maestro by coordinate. Every direction dismisses and reports `SWIPE_COMPLETE`:

<img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/issue-221/swipe-proof.gif" width="320" alt="Swipe-to-dismiss in all four directions on an iOS simulator" />

[The same run as MP4](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/issue-221/swipe-proof.mp4), if the GIF is too coarse.

The harness reports the hide reason per direction, so the state after the fourth swipe covers all four:

<img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/issue-221/swipe-all-four-reasons.png" width="300" alt="All four directions reporting SWIPE_COMPLETE" />

Intermediate states, after the up, down and left swipes:

| after up | after down | after left |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/issue-221/after-up.png" width="170" alt="up reports SWIPE_COMPLETE, the rest still none" /> | <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/issue-221/after-down.png" width="170" alt="up and down report SWIPE_COMPLETE" /> | <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/issue-221/after-left.png" width="170" alt="up, down and left report SWIPE_COMPLETE" /> |

Jest and the coordinate-driven flow:

<img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/issue-221/proof-tests.png" width="900" alt="20 jest tests passing and the Maestro run completing every step" />

## Checks

Rebased on `main` after #236. `turbo run doctor typecheck lint test format build` is green across the workspace, including the `--max-warnings 0` lint gate that #236 added.
