### PR TITLE
chore(format): reformat MagicModal.swipe.test.tsx for prettier 3.9.6

### DIFF
--- a/packages/modal/src/components/MagicModal.swipe.test.tsx
+++ b/packages/modal/src/components/MagicModal.swipe.test.tsx
@@ -114,8 +114,7 @@ const runOnUpdate = (
   translation: { translationX: number; translationY: number },
 ) => {
   const onUpdate = config.onUpdate as
-    | ((event: UpdateEvent) => void)
-    | undefined;
+    ((event: UpdateEvent) => void) | undefined;
 
   onUpdate?.({ ...baseEvent, ...translation } as unknown as UpdateEvent);
 };


### PR DESCRIPTION
Main's Format step is red. #241 added `packages/modal/src/components/MagicModal.swipe.test.tsx` formatted with prettier 3.8.3, #239 raised prettier to 3.9.6, and they merged in that order, so neither PR's own run ever saw the combination.

One line, the same union wrap 3.9.6 asked for in `constants/types.ts`:

```diff
-    | ((event: UpdateEvent) => void)
-    | undefined;
+    ((event: UpdateEvent) => void) | undefined;
```

The `push: main` trigger #236 added is what surfaced it, on [this run](https://github.com/GSTJ/react-native-magic-modal/actions/workflows/branch-validation.yml). Before that, Publish was the only workflow watching main and it would have sat green until the next PR inherited the failure.

`typecheck`, `lint`, `test` and `format` all pass locally on this branch with the turbo cache forced off.
