### PR TITLE
chore(release): sync main to 8.0.0 and open the sync PR from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
 jobs:
   release:
     name: 🎉 Release
-    if: "!contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    # release-it writes "[skip ci]", with a space. The old guard looked for
+    # "[skip-ci]" and never matched anything.
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: 🏗 Setup Repo
@@ -106,8 +111,11 @@ jobs:
           BOUNDARY=$(echo "$CANDIDATES" | xargs -I{} git log -1 --pretty="%ct %H" {} 2>/dev/null | sort -rn | head -1 | awk '{print $2}')
           echo "boundary=$BOUNDARY ($(git log -1 --pretty=%s "$BOUNDARY"))"
 
-          # A commit qualifies if EITHER:
-          #   - its subject (first line) has `(modal)` scope, OR
+          # A commit qualifies if ANY of:
+          #   - its subject (first line) has `(modal)` scope,
+          #   - its subject marks a breaking change with `!` before the colon
+          #     (`feat!:`, `fix(deps)!:`), which conventional-commits treats as
+          #     a major on its own, with or without a footer,
           #   - its body contains a line starting with `BREAKING CHANGE:`
           #     or `BREAKING-CHANGE:` (the conventional-commits footer).
           # We can't use `git log --grep` here because that searches the
@@ -123,7 +131,7 @@ jobs:
             sha=$(printf '%s' "$entry" | awk -F"$UNIT" '{print $1}')
             subject=$(printf '%s' "$entry" | awk -F"$UNIT" '{print $2}')
             body=$(printf '%s' "$entry" | awk -F"$UNIT" '{for(i=3;i<=NF;i++) printf "%s%s", $i, (i<NF?FS:"")}')
-            if printf '%s' "$subject" | grep -q '(modal)'; then
+            if printf '%s' "$subject" | grep -qE '\(modal\)|^[a-zA-Z]+(\([^)]*\))?!:'; then
               QUALIFY="${QUALIFY}${subject}"$'\n'
               continue
             fi
@@ -152,3 +160,42 @@ jobs:
           git config --global user.name "Gabriel Taveira"
           npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
           pnpm run release
+
+      - name: 🔁 Open version sync PR
+        if: steps.next-version.outputs.skip != 'true'
+        # release-it commits the version bump and the generated CHANGELOG.md on
+        # the runner but doesn't push (see packages/modal/.release-it.js), so
+        # main never saw either. That's how main ended up on 7.0.3 while npm was
+        # on 7.1.0, with no 7.0.3 or 7.1.0 section in the changelog.
+        #
+        # continue-on-error because npm has already published by this point.
+        # A failure here is a stale main, not a broken release.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./packages/modal/package.json').version")
+          if [ "$VERSION" = "${{ steps.next-version.outputs.current }}" ]; then
+            echo "Version is still $VERSION, nothing to sync."
+            exit 0
+          fi
+
+          BRANCH="chore/release-sync-$VERSION"
+          git push --force origin "HEAD:refs/heads/$BRANCH"
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR for $BRANCH already open."
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): sync magic modal version with npm $VERSION" \
+            --body "$(printf '%s\n' \
+              "release-it published $VERSION to npm and tagged magic-modal-$VERSION, then stopped." \
+              "" \
+              "It can't push to main (GH_PAT is rejected by the ruleset), so the version bump and" \
+              "the generated changelog live only on the release runner. This is that commit." \
+              "" \
+              "Opened by the 🚀 Publish workflow, run ${{ github.run_id }}.")"

--- a/packages/modal/.release-it.js
+++ b/packages/modal/.release-it.js
@@ -53,22 +53,18 @@ export default {
           },
         ],
       },
-      /**
-       * Include commits scoped to (modal) and any commit carrying a
-       * BREAKING CHANGE note (regardless of scope). This ensures that
-       * unscoped `feat!:` / `fix!:` commits or commits with a
-       * `BREAKING CHANGE:` footer still trigger a release, while
-       * unrelated chore/deps noise without (modal) scope is ignored.
-       * @param {{ header?: string, notes?: Array<{ title?: string, text?: string }> }} commit
-       */
-      commitFilter: (commit) => {
-        if (commit.header?.includes("(modal)")) return true;
-        if (
-          commit.notes?.some((n) => /BREAKING[- ]CHANGE/i.test(n.title ?? ""))
-        )
-          return true;
-        return false;
-      },
+      // There used to be a `commitFilter` here meant to keep the changelog to
+      // (modal)-scoped and breaking commits. @release-it/conventional-changelog
+      // accepts `preset`, `context`, `gitRawCommitsOpts`, `parserOpts`,
+      // `writerOpts` and `whatBump`, so it was silently dropped: the 7.1.0
+      // release notes list `fix(ci): stop turbo from swallowing the docs task`,
+      // which the filter claimed to exclude.
+      //
+      // Whether a release happens at all is decided by the "Determine next
+      // version" probe in .github/workflows/release.yml, which does check for
+      // (modal) scope and BREAKING CHANGE footers. Once a release is running,
+      // every non-hidden commit in range belongs in the notes, so there's
+      // nothing left for a filter to do.
     },
   },
   git: {
@@ -85,12 +81,14 @@ export default {
     //
     // Keeping `commit: true` and `tag: true` so the @release-it/github plugin
     // still has a tag to attach the GitHub Release to within the runner.
-    // The bump commit + tag exist only on the runner and are discarded when
-    // the job ends; main stays at the pre-release version, and we sync via
-    // a follow-up PR (same pattern used for #192).
+    // The bump commit + tag exist only on the runner. The "Open version sync
+    // PR" step in .github/workflows/release.yml pushes that commit to a branch
+    // and opens a PR, so the version and CHANGELOG.md still reach main. Main
+    // stays at the pre-release version until that PR merges.
     //
     // TODO: once GH_PAT is rotated with `contents: write` and granted
-    // bypass on branch protection, flip `push` back to `true`.
+    // bypass on the main ruleset, flip `push` back to `true` and drop the
+    // sync-PR step.
     push: false,
     requireCleanWorkingDir: false,
     tagName: "magic-modal-${version}",

--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,5 +1,46 @@
 # 🦄 Magic Modal Changelog 🪄
 
+## [8.0.0](https://github.com/GSTJ/react-native-magic-modal/compare/magic-modal-7.1.0...magic-modal-8.0.0) (2026-07-27)
+
+### ⚠ BREAKING CHANGES
+
+* **modal:** the `react-native-gesture-handler` peer range moves from
+`>=2.20.0` to `>=3.0.0`. `usePanGesture` only exists in 3.x, so there's no
+2.x-compatible path. The modal's own API is unchanged. A
+`GestureHandlerRootView` above the portal also becomes mandatory, since 3.x
+throws where 2.x only logged a warning. Expo SDK 55 still pins gesture-handler
+to 2.30, so Expo projects installing 3.x need it in `expo.install.exclude`, or
+can stay on `react-native-magic-modal` 7.x until Expo moves the pin.
+
+### :hammer: Bug Fixes :hammer:
+
+* **ci:** stop registering two [@typescript-eslint](https://github.com/typescript-eslint) plugin instances ([#236](https://github.com/GSTJ/react-native-magic-modal/issues/236)) ([a8ce4f9](https://github.com/GSTJ/react-native-magic-modal/commit/a8ce4f92768f0b78e7149b2f3ee7b2c492ec3ab1)), closes [#228](https://github.com/GSTJ/react-native-magic-modal/issues/228) [#233](https://github.com/GSTJ/react-native-magic-modal/issues/233) [#219](https://github.com/GSTJ/react-native-magic-modal/issues/219)
+* **deps:** drop the duplicate hasown entry that broke the lockfile ([#220](https://github.com/GSTJ/react-native-magic-modal/issues/220)) ([76f92fe](https://github.com/GSTJ/react-native-magic-modal/commit/76f92fe2f1bf37c17a84115671bb81efcdb9e3f3))
+
+### :stars: New Features :stars:
+
+* **modal:** move swipe-to-dismiss onto gesture-handler's usePanGesture ([#241](https://github.com/GSTJ/react-native-magic-modal/issues/241)) ([61a4080](https://github.com/GSTJ/react-native-magic-modal/commit/61a4080c75af410c85a94346c6024b1c635d0016))
+
+## [7.1.0](https://github.com/GSTJ/react-native-magic-modal/compare/magic-modal-7.0.3...magic-modal-7.1.0) (2026-07-25)
+
+### :stars: New Features :stars:
+
+* **modal:** add update() to swap a modal's content in place ([#217](https://github.com/GSTJ/react-native-magic-modal/issues/217)) ([24a939f](https://github.com/GSTJ/react-native-magic-modal/commit/24a939f2bf00d825c44e43b06bc4919759fce628))
+
+### :hammer: Bug Fixes :hammer:
+
+* **ci:** stop turbo from swallowing the docs task ([#215](https://github.com/GSTJ/react-native-magic-modal/issues/215)) ([18966e0](https://github.com/GSTJ/react-native-magic-modal/commit/18966e09880e26e6255af25ebc1eb119dade9e88))
+
+## 7.0.3 (2026-07-25)
+
+### :hammer: Bug Fixes :hammer:
+
+* **modal:** stop the swipe gesture from eating taps ([#205](https://github.com/GSTJ/react-native-magic-modal/issues/205)) ([dc0a98c](https://github.com/GSTJ/react-native-magic-modal/commit/dc0a98c3413f85b0497ee07dd252ac34f464d83a))
+
+### :link: Testing Updated :link:
+
+* bring jest back to life and run it in CI ([#201](https://github.com/GSTJ/react-native-magic-modal/issues/201)) ([1864ea9](https://github.com/GSTJ/react-native-magic-modal/commit/1864ea9a74a803e2ead35e02a243b70e8d6721b6))
+
 ## 7.0.2 (2026-05-19)
 
 ### :curly_loop: Continuous Integrations :curly_loop:

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-magic-modal",
-  "version": "7.0.3",
+  "version": "8.0.0",
   "type": "module",
   "description": "A magic modal that can be used imperatively from anywhere! 🦄",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Sets main to 8.0.0, backfills the 7.0.3, 7.1.0 and 8.0.0 `CHANGELOG.md` sections, and makes Publish open the version sync PR itself. Replaces #240, which was written when npm was still on 7.1.0.

release-it commits the bump and the generated changelog on the runner and `git.push` is `false`, so neither reaches main. #241 published 8.0.0 to npm and tagged `magic-modal-8.0.0` while main's `packages/modal/package.json` stayed on 7.0.3, and `CHANGELOG.md` had nothing for 7.0.3, 7.1.0 or 8.0.0. 7.0.2 got synced by hand in #212; the three after it never did.

Left alone, the next patch computes 7.0.4 off 7.0.3, which npm rejects as behind `latest`.

The 8.0.0 and 7.1.0 sections are the generated release notes verbatim. 7.0.3's release body regenerated the history from the first commit, because no `magic-modal-*` tag existed when it ran, so its section here is the two commits between 7.0.2 and 7.0.3: `fix(modal): stop the swipe gesture from eating taps` (#205) and `test: bring jest back to life and run it in CI` (#201).

The new `🔁 Open version sync PR` step pushes release-it's bump commit to `chore/release-sync-<version>` and opens a PR against main, under `continue-on-error` since npm has already published by then and a failed sync shouldn't red the release job.

The job guard was matching a hyphenated `skip-ci` marker; release-it writes the space-separated one, so the guard never matched. GitHub's own handling of that marker has been suppressing the re-run. (The literal marker is paraphrased here because spelling it out in a commit message makes GitHub skip every workflow on the push.)

`.release-it.js` carried a `commitFilter` meant to hold the changelog to `(modal)`-scoped and breaking commits. `@release-it/conventional-changelog` takes `preset`, `context`, `gitRawCommitsOpts`, `parserOpts`, `writerOpts` and `whatBump`, so the filter was dead config: the 8.0.0 notes list `fix(ci): stop registering two @typescript-eslint plugin instances`, exactly what it claimed to drop. It's gone, with a comment pointing at the `🔎 Determine next version` step in `release.yml`, which is what gates the release.

## The probe was blind to a bare `!`

Its comment claimed an unscoped `feat!:` triggers a release, but the subject test only looked for `(modal)`, so a major carrying no `BREAKING CHANGE:` footer got silently skipped. #241 happened to have both, which is why 8.0.0 went out. It now matches the conventional-commits `!` before the colon too:

![release probe verdicts for scoped, bang-marked and footer-marked commits](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/gstj/pr-assets-dump/ci/release-probe-breaking-change.png)

`doctor`, `typecheck`, `lint`, `test` and `format` all pass locally on this branch with the turbo cache forced off.
