### PR TITLE
fix(ci): move onto the node 24 action majors and unbreak the docs build

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🏗 Setup PNPM
         uses: pnpm/action-setup@v4
@@ -30,7 +30,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - "packages/modal/**"
+  # The path filter means a workflow-only change can't redeploy the site, so
+  # a broken docs build stays broken until packages/modal happens to move.
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -22,17 +25,25 @@ concurrency:
 jobs:
   deploy-docs:
     name: 🚀 Deploy Docs
-    if: "!contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    # release-it writes "[skip ci]", with a space. The old guard looked for
+    # "[skip-ci]" and never matched anything, same bug release.yml had.
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     runs-on: ubuntu-latest
 
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
+      # No version pin: the action reads `packageManager` from the root
+      # package.json, same as every other workflow. Pinning pnpm 8 here is
+      # what broke the docs build. `nodeLinker: hoisted` moved from .npmrc to
+      # pnpm-workspace.yaml in #224, and pnpm 8 doesn't read settings from
+      # pnpm-workspace.yaml, so it installed an isolated store instead. That
+      # leaves `expo` out of the root node_modules, and packages/modal's
+      # tsconfig extends `expo/tsconfig.base`, so typedoc died on
+      # "File 'expo/tsconfig.base' not found".
       - name: 🏗 Setup PNPM
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
 
       - name: 🏗 Get PNPM store directory
         id: pnpm-cache
@@ -40,7 +51,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -53,7 +64,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: "📦 Cache Node Modules"
-        uses: actions/cache@v5.1.0
+        uses: actions/cache@v6.1.0
         id: cache-node-modules
         with:
           path: node_modules
@@ -68,7 +79,7 @@ jobs:
         uses: dtinth/setup-github-actions-caching-for-turbo@v1
 
       - name: 🛠️ Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: 📚 Generate Docs
         run: pnpm run docs
@@ -80,4 +91,4 @@ jobs:
 
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🏗 Select Xcode 26 (Swift 6.1+ for expo-modules-core)
         run: |
@@ -113,7 +113,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -139,7 +139,7 @@ jobs:
       # success; restore/save lets us save unconditionally.
       - name: 🗄 Restore ccache compiler cache
         id: ccache-restore
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -148,7 +148,7 @@ jobs:
 
       - name: 🗄 Restore CocoaPods (specs + downloaded sources)
         id: pods-cache-restore
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cocoapods
@@ -159,7 +159,7 @@ jobs:
 
       - name: 🗄 Restore iOS Pods/build/DerivedData
         id: ios-cache-restore
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: |
             ${{ env.EXAMPLE_DIR }}/ios/Pods
@@ -252,14 +252,14 @@ jobs:
       # GHA cache quota re-uploading identical contents.
       - name: 💾 Save ccache compiler cache
         if: always() && steps.ccache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: ~/.ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
       - name: 💾 Save CocoaPods cache
         if: always() && steps.pods-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: |
             ~/.cocoapods
@@ -268,7 +268,7 @@ jobs:
 
       - name: 💾 Save iOS Pods/build/DerivedData cache
         if: always() && steps.ios-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: |
             ${{ env.EXAMPLE_DIR }}/ios/Pods

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: 🏗 Setup Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Need full history so the no-op probe below can locate the last
           # release boundary commit and grep for qualifying commits since.
@@ -40,7 +40,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: 🏗 Setup PNPM cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -53,7 +53,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: "📦 Cache Node Modules"
-        uses: actions/cache@v5.1.0
+        uses: actions/cache@v6.1.0
         id: cache-node-modules
         with:
           path: node_modules


### PR DESCRIPTION
actions/cache v5 -> v6, actions/checkout v6 -> v7, actions/configure-pages v5 -> v6, actions/deploy-pages v4 -> v5. All four are node 24 runtime moves. Node 20 is deprecated and the runner is already force-running our node20 actions on 24.

They go in together because #241 and #239 were each green on their own and main went red on the combination.

## Compatibility

cache v6 is an ESM rewrite. `action.yml`, `restore/action.yml` and `save/action.yml` are identical to v5.1.0, so the `cache-primary-key` output that the split restore/save steps in `e2e-ios.yml` read is still there.

checkout v7 refuses to check out fork PR code under `pull_request_target` and `workflow_run`. This repo triggers on `pull_request`, `pull_request_review` and `push`, so the guard never fires. `action.yml` is otherwise identical to v6.1.0.

configure-pages v6 and deploy-pages v5 change one line each in `action.yml`, `using: node20` to `using: node24`. deploy-pages v5 still reads the `github-pages` artifact name, so `upload-pages-artifact@v3` stays.

The diffs I read: [action-yml-diffs.txt](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/actions-node24-majors/action-yml-diffs.txt)

## Docs

Two of the four bumps only touch `docs.yml`, which has been red since #236 with `File 'expo/tsconfig.base' not found`. The fix is in this PR.

`docs.yml` pinned pnpm 8, and #224 moved `nodeLinker: hoisted` out of `.npmrc` into `pnpm-workspace.yaml`, which pnpm 8 doesn't read. So the docs job installed an isolated store, `expo` never landed in the root `node_modules`, and `packages/modal/tsconfig.json` couldn't resolve the base config it extends. Dropping the version pin picks up pnpm 10.34.5 from `packageManager`, same as the other three workflows.

The failing run: [docs-failure-30231384635.log](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/actions-node24-majors/docs-failure-30231384635.log), where the install logs `Virtual store is at: node_modules/.pnpm`. Same commit under pnpm 10.34.5, locally: [docs-build-local.log](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/actions-node24-majors/docs-build-local.log), 0 errors.

The `[skip-ci]` guard on the same job never matched anything either, because release-it writes `[skip ci]` with a space. `release.yml` got that fix in #248 and `docs.yml` didn't.

`workflow_dispatch` is new. The `packages/modal/**` path filter keeps a workflow-only change from redeploying the site.

Dispatched it after merging: [run 30233700296](https://github.com/GSTJ/react-native-magic-modal/actions/runs/30233700296), green, and https://gstj.github.io/react-native-magic-modal/ picked up the 8.0.0 README. The site had been stuck on the pre-8.0.0 build since #236, so the peer version table, the `usePanGesture` note and the `expo.install.exclude` note were all missing from it.

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/actions-node24-majors/docs-installation-before.png" width="420" alt="Installation section with no peer version table" /> | <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/actions-node24-majors/docs-installation-after.png" width="420" alt="Installation section with the minimum peer versions table and the gesture-handler 3.0.0 row" /> |

## Checks

Both green on the combined branch: [Branch Checkup](https://github.com/GSTJ/react-native-magic-modal/actions/runs/30232536258) and [E2E iOS](https://github.com/GSTJ/react-native-magic-modal/actions/runs/30232536236), the latter through `cache/restore@v6`, the Release build, both Maestro flows and all three `cache/save@v6` steps.

Supersedes #244, #245, #249 and #250.
