### PR TITLE
fix(ci): auto-merge the release sync PR past the required check

### DIFF
--- a/.github/actions/approve-parked-ci/action.yml
+++ b/.github/actions/approve-parked-ci/action.yml
@@ -1,0 +1,52 @@
+name: Approve parked CI
+description: >
+  Releases the pull_request runs that GitHub parks at conclusion
+  action_required when a PR is opened with GITHUB_TOKEN. The ruleset on main
+  only reads checks attached to the PR, so a parked run leaves the PR unable to
+  merge. GITHUB_TOKEN is allowed to approve a run it triggered.
+
+inputs:
+  pull-request:
+    description: Number of the pull request whose runs should be released.
+    required: true
+  token:
+    description: Token with actions:write on this repository.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR: ${{ inputs.pull-request }}
+      run: |
+        set -euo pipefail
+
+        sha=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)
+        echo "pull request #$PR is at $sha"
+
+        # The runs show up after the PR does, so poll for them and approve
+        # every parked one. Both Branch Checkup and the iOS E2E trigger on
+        # pull_request, so there's more than one.
+        # 3 minutes. The runs list is indexed a little behind the events, and
+        # a head_sha query has come back empty for a run whose check suite was
+        # already in_progress.
+        approved=0
+        for _ in $(seq 1 30); do
+          ids=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$sha" \
+            --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')
+          if [ -n "$ids" ]; then
+            for id in $ids; do
+              gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/approve"
+              echo "approved run $id"
+              approved=$((approved + 1))
+            done
+            break
+          fi
+          sleep 6
+        done
+
+        if [ "$approved" = "0" ]; then
+          echo "::warning::no parked pull_request run for $sha. Check whether it got a Branch Checkup run at all."
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,32 +3,64 @@ name: 🚀 Publish
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sync_pr_dry_run:
+        description: >
+          Skip the release and drive the sync PR steps with an empty commit.
+          Checks that path without cutting a release.
+        type: boolean
+        default: false
 
 jobs:
   release:
     name: 🎉 Release
     # release-it writes "[skip ci]", with a space. The old guard looked for
-    # "[skip-ci]" and never matched anything.
+    # "[skip-ci]" and never matched anything. github.event.commits is null on
+    # workflow_dispatch, so toJSON gives "null" and the guard lets it through.
     if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+      # Needed to POST actions/runs/{id}/approve. A PR opened with
+      # GITHUB_TOKEN gets its pull_request run parked at action_required, and
+      # the ruleset only counts checks attached to the PR.
+      actions: write
 
     steps:
+      # Resolved in shell rather than in an `if:` expression. A boolean
+      # workflow_dispatch input reaches expressions as a string in some places
+      # and a boolean in others, and `inputs` isn't populated at all on push,
+      # so `inputs.sync_pr_dry_run == true` is not something to bet the
+      # publish path on. `github.event.inputs.*` renders to "true", "false" or
+      # "" every time.
+      - name: 🔀 Pick the mode
+        id: mode
+        env:
+          RAW: ${{ github.event.inputs.sync_pr_dry_run }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] && [ "$RAW" = "true" ]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "Dry run. No release, no publish."
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 🏗 Setup Repo
         uses: actions/checkout@v7
         with:
           # Need full history so the no-op probe below can locate the last
           # release boundary commit and grep for qualifying commits since.
           fetch-depth: 0
-          # PAT lets release-it push the version-bump commit + tag back to
-          # main past branch protection (GITHUB_TOKEN can't bypass rules).
-          # NOTE: GH_PAT was failing with "Permission denied" on push (likely
-          # expired/missing contents:write). We keep this here in case it gets
-          # rotated, but `.release-it.js` now sets `git.push: false` so the
-          # workflow no longer depends on it actually working.
-          token: ${{ secrets.GH_PAT }}
+          # No GH_PAT here on purpose. It used to be checked out so release-it
+          # could push the bump commit straight to main, and it failed with
+          # "Permission denied". `.release-it.js` sets `git.push: false` now, so
+          # nothing in this job needs a PAT, and the credential that stays in
+          # the local git config has to be one that can actually push. The sync
+          # PR branch below is pushed with it, and GITHUB_TOKEN can write
+          # `chore/release-sync-*` because the ruleset only covers main.
           persist-credentials: true
 
       - name: 🏗 Setup PNPM
@@ -72,6 +104,7 @@ jobs:
 
       - name: 🔎 Determine next version
         id: next-version
+        if: steps.mode.outputs.dry_run == 'false'
         working-directory: packages/modal
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,19 +112,22 @@ jobs:
           # We can't trust `release-it --release-version` here: when no commits
           # match the `(modal)` scope filter, the conventional-changelog plugin
           # returns no recommendation and release-it's Version plugin falls
-          # back to a CI-default `patch` of `latestVersion` (which is `0.0.0`
-          # because there's no `magic-modal-*` git tag yet). That made the
-          # probe print `0.0.1` even with zero qualifying commits, so the
+          # back to a CI-default `patch` of `latestVersion`. That made the
+          # probe print a version even with zero qualifying commits, so the
           # script proceeded to publish.
           #
           # Instead, decide skip deterministically from git history. The
           # boundary is the most recent of:
-          #   - last `magic-modal-*` tag (preferred, once we ever push one)
-          #   - last `chore(release):` commit (release-it's own bump commit)
+          #   - last `magic-modal-*` tag. release-it never pushes one (see
+          #     .release-it.js), but the @release-it/github plugin creates the
+          #     GitHub Release, and that creates the tag ref, so
+          #     magic-modal-7.0.3, -7.1.0 and -8.0.0 do exist on the remote.
+          #   - last `chore(release):` commit (release-it's own bump commit,
+          #     which reaches main as the squash of the sync PR below)
           #   - last `chore(modal): sync version` commit (manual sync fallback)
-          # We then look for any commit since the boundary whose subject is
-          # `(modal)`-scoped OR whose body has a `BREAKING CHANGE:` footer.
-          # This mirrors the commitFilter in packages/modal/.release-it.js.
+          # We then look for any commit since the boundary that qualifies for a
+          # release. `packages/modal/.release-it.js` no longer filters commits,
+          # so this probe is the only thing deciding whether one happens.
           CURRENT=$(node -p "require('./package.json').version")
           echo "current=$CURRENT"
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
@@ -102,7 +138,7 @@ jobs:
           CANDIDATES=$(printf '%s\n%s\n%s\n' "$TAG_BOUND" "$REL_BOUND" "$SYNC_BOUND" | grep -v '^$' || true)
 
           if [ -z "$CANDIDATES" ]; then
-            # No boundary at all (fresh repo) — let the release flow run.
+            # No boundary at all (fresh repo), so let the release flow run.
             echo "No release boundary found; proceeding."
             echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -151,7 +187,7 @@ jobs:
           fi
 
       - name: 🚀 Release
-        if: steps.next-version.outputs.skip != 'true'
+        if: steps.next-version.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -161,41 +197,110 @@ jobs:
           npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
           pnpm run release
 
+      # A release happens rarely, so the steps below it can sit unexecuted for
+      # weeks. This one stands in for release-it's version bump so they can be
+      # driven on demand, with no publish and no version change. Dispatch the
+      # workflow with sync_pr_dry_run to use it.
+      - name: 🧪 Stage a dry-run commit
+        id: dry-run
+        if: steps.mode.outputs.dry_run == 'true'
+        run: |
+          git config --global user.email "gabrielstaveira@gmail.com"
+          git config --global user.name "Gabriel Taveira"
+          git commit --allow-empty \
+            -m "chore(ci): dry-run the release sync PR path" \
+            -m "An empty commit standing in for release-it's version bump. Driven by the Publish workflow with sync_pr_dry_run, run ${{ github.run_id }}."
+
       - name: 🔁 Open version sync PR
-        if: steps.next-version.outputs.skip != 'true'
+        id: sync-pr
+        if: steps.mode.outputs.dry_run == 'true' || steps.next-version.outputs.skip == 'false'
         # release-it commits the version bump and the generated CHANGELOG.md on
         # the runner but doesn't push (see packages/modal/.release-it.js), so
         # main never saw either. That's how main ended up on 7.0.3 while npm was
         # on 7.1.0, with no 7.0.3 or 7.1.0 section in the changelog.
         #
         # continue-on-error because npm has already published by this point.
-        # A failure here is a stale main, not a broken release.
+        # A failure here leaves main stale, which the next release can still fix.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          VERSION_BEFORE: ${{ steps.next-version.outputs.current }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          VERSION=$(node -p "require('./packages/modal/package.json').version")
-          if [ "$VERSION" = "${{ steps.next-version.outputs.current }}" ]; then
-            echo "Version is still $VERSION, nothing to sync."
-            exit 0
-          fi
+          set -euo pipefail
 
-          BRANCH="chore/release-sync-$VERSION"
-          git push --force origin "HEAD:refs/heads/$BRANCH"
-
-          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
-            echo "PR for $BRANCH already open."
-            exit 0
-          fi
-
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(release): sync magic modal version with npm $VERSION" \
-            --body "$(printf '%s\n' \
-              "release-it published $VERSION to npm and tagged magic-modal-$VERSION, then stopped." \
+          if [ "$DRY_RUN" = "true" ]; then
+            BRANCH="chore/release-sync-dry-run-$RUN_ID"
+            TITLE="chore(ci): dry-run the release sync PR path"
+            BODY=$(printf '%s\n' \
+              "An empty commit standing in for release-it's version bump. No publish, no version" \
+              "change." \
               "" \
-              "It can't push to main (GH_PAT is rejected by the ruleset), so the version bump and" \
+              "A PR opened from CI with GITHUB_TOKEN gets its pull_request run parked at" \
+              "action_required, so the context the main ruleset requires never reports. The" \
+              "Publish workflow approves the parked run and turns on auto-merge. This PR should" \
+              "merge on its own." \
+              "" \
+              "Opened by the Publish workflow, run $RUN_ID.")
+          else
+            VERSION=$(node -p "require('./packages/modal/package.json').version")
+            if [ "$VERSION" = "$VERSION_BEFORE" ]; then
+              echo "Version is still $VERSION, nothing to sync."
+              exit 0
+            fi
+            BRANCH="chore/release-sync-$VERSION"
+            TITLE="chore(release): sync magic modal version with npm $VERSION"
+            BODY=$(printf '%s\n' \
+              "release-it published $VERSION to npm and tagged magic-modal-$VERSION." \
+              "" \
+              "It doesn't push to main (see packages/modal/.release-it.js), so the version bump and" \
               "the generated changelog live only on the release runner. This is that commit." \
               "" \
-              "Opened by the 🚀 Publish workflow, run ${{ github.run_id }}.")"
+              "Opened by the Publish workflow, run $RUN_ID.")
+          fi
+
+          git push --force origin "HEAD:refs/heads/$BRANCH"
+
+          PR=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number')
+          if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+            gh pr create --base main --head "$BRANCH" --title "$TITLE" --body "$BODY"
+            PR=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number')
+          else
+            echo "PR #$PR for $BRANCH already open."
+          fi
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: ✅ Release the parked check run
+        if: steps.sync-pr.outputs.pr != ''
+        continue-on-error: true
+        uses: ./.github/actions/approve-parked-ci
+        with:
+          pull-request: ${{ steps.sync-pr.outputs.pr }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Nothing was merging these. #240 and #247 both sat open until someone
+      # closed them by hand, which is how main drifts from npm.
+      - name: 🤝 Turn on auto-merge
+        if: steps.sync-pr.outputs.pr != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.sync-pr.outputs.pr }}
+        run: |
+          if gh pr merge "$PR" --auto --squash --delete-branch; then
+            echo "auto-merge armed on #$PR"
+            exit 0
+          fi
+
+          # GitHub rejects --auto on a PR that is already CLEAN, which happens
+          # if Branch Checkup finished while the approve step was still polling.
+          STATE=$(gh pr view "$PR" --json mergeStateStatus --jq .mergeStateStatus)
+          echo "auto-merge was rejected, mergeStateStatus=$STATE"
+          if [ "$STATE" = "CLEAN" ]; then
+            gh pr merge "$PR" --squash --delete-branch
+          else
+            echo "::warning::#$PR is $STATE and auto-merge did not take. Needs a look."
+          fi


### PR DESCRIPTION
main requires the `👮‍♂️ Typecheck, Healthcheck, Lint and Format` context now, and #248's sync PR step could never clear it. None of that had surfaced, because the step hasn't executed once since it was written: 8.0.0 was the last release, #248 landed after it, and every Publish run since has skipped.

## The branch push used GH_PAT

`git push --force origin "HEAD:refs/heads/$BRANCH"` uses whatever credential `actions/checkout` persisted, and the checkout was passing `token: ${{ secrets.GH_PAT }}`. That's the token `.release-it.js` documents as rejected with "Permission denied".

Nothing in this job needs a PAT anymore, so the checkout drops it. The persisted credential becomes `GITHUB_TOKEN`, which can write `chore/release-sync-*` because the ruleset only covers main.

## The required check never reports

A PR opened with `GITHUB_TOKEN` gets its `pull_request` run parked at `conclusion: action_required`. The context stays pending, the ruleset only reads checks attached to the PR, and the PR can't merge.

`.github/actions/approve-parked-ci` POSTs `actions/runs/{id}/approve` for every parked run on the head sha, which `GITHUB_TOKEN` is allowed to do for a run it triggered. It loops over all of them, because Branch Checkup and the iOS E2E both trigger on `pull_request`. That needs `actions: write` on the job.

## Nothing merged the PR

#240 and #247 both sat open until someone closed them by hand. The workflow turns on auto-merge, so the PR lands once Branch Checkup goes green.

## Dry run

`sync_pr_dry_run` on `workflow_dispatch` drives every step above with an empty commit, no publish and no version change. Until now the only way to reach that code was to cut a release.

## Other changes

Both sync guards move from `!= 'true'` to `== 'false'`. The probe writes `skip` explicitly on every path, and an empty output shouldn't read as "release".

The probe's comments claimed no `magic-modal-*` tag exists, and that its qualifying-commit rules mirror a `commitFilter` in `.release-it.js`. Neither is true. `magic-modal-7.0.3`, `-7.1.0` and `-8.0.0` are all remote tag refs, created by `@release-it/github` when it cut each Release, and the `commitFilter` came out in #248.

I also ran the probe against synthetic histories to confirm the `feat!:` handling #196 added holds: an unscoped `feat!:` and `fix!:` both release, a `BREAKING CHANGE:` footer under an unscoped subject releases, and prose mentioning `BREAKING CHANGE` or `(modal)` in a body does not.

Dispatched it after merging: [run 30233837544](https://github.com/GSTJ/react-native-magic-modal/actions/runs/30233837544). It opened #256, found two parked `pull_request` runs on the head sha and approved both, armed auto-merge, and #256 squashed itself into main as fc09151 at 03:10:34 with nobody touching it. `packages/modal/package.json` and npm both still say 8.0.0.

Two things that run turned up. `--delete-branch` doesn't take with `--auto` while the repo has `delete_branch_on_merge` off, so the sync branch needs deleting by hand or that setting turning on. And no workflow ran on the resulting push to main, which is the documented GITHUB_TOKEN behaviour, so a release sync can't loop back into Publish.
