### PR TITLE
feat(modal): support gesture-handler 2.x alongside 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Minimum peer versions:
 | `react-native-gesture-handler` | 2.20.0  |
 | `react-native-reanimated`      | 4.0.0   |
 
-Both gesture-handler majors work. Swipe-to-dismiss uses 3.x's `usePanGesture` hook when it's available and falls back to 2.x's `Gesture.Pan()` builder when it isn't.
+Both gesture-handler majors work. Swipe-to-dismiss uses 3.x's `usePanGesture` hook when it's available and falls back to 2.x's `Gesture.Pan()` builder otherwise.
 
-On Expo there's nothing to do: `npx expo install react-native-gesture-handler` gives you whatever your SDK bundles, which is 2.x on every SDK through 57, and `npx expo-doctor` stays clean. If you added `react-native-gesture-handler` to `expo.install.exclude` to quiet the version check on 8.0.0, drop it.
+On Expo there's nothing to do: `npx expo install react-native-gesture-handler` gives you whatever your SDK bundles, which is 2.x on every SDK through 57, and `npx expo-doctor` stays clean.
 
-8.0.0 required gesture-handler 3.x. If you're on 8.0.0 and pinned to 2.x, upgrade to 8.1.0 or later.
+8.0.0 was the one version that required gesture-handler 3.x. If you're on it and pinned to 2.x, upgrade to 8.1.0 or later, and drop `react-native-gesture-handler` from `expo.install.exclude` if you added it to quiet the version check.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ Minimum peer versions:
 | ------------------------------ | ------- |
 | `react`                        | 18.0.0  |
 | `react-native`                 | 0.81.0  |
-| `react-native-gesture-handler` | 3.0.0   |
+| `react-native-gesture-handler` | 2.20.0  |
 | `react-native-reanimated`      | 4.0.0   |
 
-The gesture-handler floor is a hard one from `react-native-magic-modal` 8.0.0 on: swipe-to-dismiss is built on the `usePanGesture` hook, which only exists in 3.x. Stay on 7.x if you're pinned to gesture-handler 2.x.
+Both gesture-handler majors work. Swipe-to-dismiss uses 3.x's `usePanGesture` hook when it's available and falls back to 2.x's `Gesture.Pan()` builder when it isn't.
 
-On Expo, that pin is worth checking. SDK 55 still asks for `react-native-gesture-handler@~2.30.0`, so `npx expo install` will pull 2.x and `npx expo-doctor` will flag 3.x as a major mismatch. Installing 3.x anyway works, and you can quiet the check by adding the package to `expo.install.exclude` in your `package.json`, the way `examples/kitchen-sink` does. Otherwise stay on `react-native-magic-modal` 7.x until Expo moves its pin.
+On Expo there's nothing to do: `npx expo install react-native-gesture-handler` gives you whatever your SDK bundles, which is 2.x on every SDK through 57, and `npx expo-doctor` stays clean. If you added `react-native-gesture-handler` to `expo.install.exclude` to quiet the version check on 8.0.0, drop it.
+
+8.0.0 required gesture-handler 3.x. If you're on 8.0.0 and pinned to 2.x, upgrade to 8.1.0 or later.
 
 ## Quickstart
 
@@ -97,7 +99,7 @@ export default function App() {
 
 Tip: the root `_layout.tsx` is usually the best place to put it in a project using expo-router.
 
-The `GestureHandlerRootView` is required. The portal renders a `GestureDetector` for the swipe gesture, and gesture-handler 3.x throws when one renders without a root view above it. 2.x only logged a warning, so apps that skipped it got away with it.
+The `GestureHandlerRootView` is required. The portal renders a `GestureDetector` for the swipe gesture, and gesture-handler 3.x throws when one renders without a root view above it. 2.x only logs a warning.
 
 ## Examples
 

--- a/packages/modal/jest.config.js
+++ b/packages/modal/jest.config.js
@@ -8,7 +8,7 @@ export default {
     "node_modules/(?!((jest-)?react-native|react-native-gesture-handler|react-native-reanimated|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)",
   ],
   coverageReporters: ["json-summary", ["text", { file: "coverage.txt" }]],
-  setupFiles: ["../../node_modules/react-native-gesture-handler/jestSetup.js"],
+  setupFiles: ["react-native-gesture-handler/jestSetup.js"],
   reporters: [
     "default",
     ["github-actions", { silent: false }],

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.81.0",
-    "react-native-gesture-handler": ">=3.0.0",
+    "react-native-gesture-handler": ">=2.20.0",
     "react-native-reanimated": ">=4.0.0",
     "react-native-worklets": ">=0.5.0"
   },

--- a/packages/modal/src/components/MagicModal.swipe.harness.tsx
+++ b/packages/modal/src/components/MagicModal.swipe.harness.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Text } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { act, render as rntlRender } from "@testing-library/react-native";
+
+import type { Direction } from "../constants/types";
+import { magicModal } from "../utils/magicModalHandler";
+import { MagicModalPortal } from "./MagicModalPortal/MagicModalPortal";
+
+/**
+ * Scaffolding shared by `MagicModal.swipe.v2.test.tsx` and
+ * `MagicModal.swipe.v3.test.tsx`.
+ *
+ * MagicModal wires the swipe up through gesture-handler 2.x's `Gesture.Pan()`
+ * builder or 3.x's `usePanGesture` hook, whichever the installed major has, so
+ * each gets its own suite. Only the interception differs. Keeping everything
+ * around it here is what makes the two suites comparable line by line.
+ *
+ * Not picked up as a suite itself: jest's testMatch only takes `*.test.tsx`.
+ */
+
+const content = "Taveira";
+
+export const ModalContent = () => <Text testID="swipe-content">{content}</Text>;
+
+export const directions = ["up", "down", "left", "right"] as const;
+
+/**
+ * Matches `TOUCH_SLOP` in `MagicModal.tsx`. Both surfaces have to forward it:
+ * without it, finger jitter during a tap activates the pan and cancels the
+ * touch on whatever the user was pressing inside the modal.
+ */
+export const expectedMinDistance = 10;
+
+interface PanVelocity {
+  velocityX: number;
+  velocityY: number;
+}
+
+/** Clears the default `swipeVelocityThreshold` by a wide margin. */
+export const fastVelocity = {
+  up: { velocityX: 0, velocityY: -900 },
+  down: { velocityX: 0, velocityY: 900 },
+  left: { velocityX: -900, velocityY: 0 },
+  right: { velocityX: 900, velocityY: 0 },
+} satisfies Record<Direction, PanVelocity>;
+
+/** Under the threshold in every direction, so the modal springs back. */
+export const slowVelocity: PanVelocity = { velocityX: 10, velocityY: 10 };
+
+/**
+ * Every field either major's pan event carries, zeroed. Each suite casts this
+ * into its own event type, which is the only part of the shape that differs.
+ */
+export const baseEvent = {
+  handlerTag: -1,
+  numberOfPointers: 1,
+  pointerType: 0,
+  x: 0,
+  y: 0,
+  absoluteX: 0,
+  absoluteY: 0,
+  stylusData: undefined,
+  translationX: 0,
+  translationY: 0,
+  changeX: 0,
+  changeY: 0,
+  velocityX: 0,
+  velocityY: 0,
+};
+
+export const showModal = (swipeDirection: Direction | undefined) => {
+  rntlRender(
+    <GestureHandlerRootView>
+      <MagicModalPortal />
+    </GestureHandlerRootView>,
+  );
+
+  let promise: Promise<unknown> | undefined;
+
+  act(() => {
+    promise = magicModal.show(() => <ModalContent />, {
+      swipeDirection,
+    }).promise;
+  });
+
+  return promise;
+};
+
+/**
+ * The dismissal spring runs for several frames and its completion callback hops
+ * from the UI thread back to JS via `scheduleOnRN`, so `hide` lands well after
+ * the end callback returns. Poll on timers, which is what drives the spring;
+ * awaiting the show promise instead deadlocks, because the frame loop doesn't
+ * advance inside `act`.
+ */
+export const waitForHide = async (isResolved: () => boolean) => {
+  for (let i = 0; i < 100 && !isResolved(); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};

--- a/packages/modal/src/components/MagicModal.swipe.v2.test.tsx
+++ b/packages/modal/src/components/MagicModal.swipe.v2.test.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { act } from "@testing-library/react-native";
+
+import type { LegacyPanGesture } from "./panGesture/PanGestureSurface.v2";
+import { MagicModalHideReason } from "../constants/types";
+import { magicModal } from "../utils/magicModalHandler";
+import {
+  baseEvent,
+  directions,
+  expectedMinDistance,
+  fastVelocity,
+  ModalContent,
+  showModal,
+  slowVelocity,
+  waitForHide,
+} from "./MagicModal.swipe.harness";
+
+/**
+ * The gesture-handler 2.x half of the swipe coverage. Its 3.x counterpart is
+ * `MagicModal.swipe.v3.test.tsx`; the assertions run in the same order so the
+ * two read side by side.
+ *
+ * 2.x has no `usePanGesture`, so `MagicModal` builds a `Gesture.Pan()` instead.
+ * The builder here is the real one, spread through from the actual module: the
+ * callbacks and the config land on the gesture object itself, which is exactly
+ * where gesture-handler's own event dispatcher reads them from. Only
+ * `GestureDetector` is stubbed, and it doubles as the interception point.
+ *
+ * Clearing `usePanGesture` in the mock pins `hasPanGestureHook` to false, so this
+ * suite drives the builder surface whichever gesture-handler is installed.
+ *
+ * The point of these tests is the callback *names*. `.onFinalize` also runs after
+ * gestures that never activated, so hanging the dismissal off it instead of
+ * `.onEnd` moves when `SWIPE_COMPLETE` resolves while still looking correct in a
+ * manual test.
+ */
+jest.mock("react-native-gesture-handler", () => {
+  const actual = jest.requireActual<Record<string, unknown>>(
+    "react-native-gesture-handler",
+  );
+
+  const capturedGestures: LegacyPanGesture[] = [];
+
+  return {
+    ...actual,
+    usePanGesture: undefined,
+    capturedGestures,
+    GestureDetector: ({
+      gesture,
+      children,
+    }: {
+      gesture: LegacyPanGesture;
+      children: React.ReactNode;
+    }) => {
+      capturedGestures.push(gesture);
+      return children;
+    },
+  };
+});
+
+const { capturedGestures } = jest.requireMock<{
+  capturedGestures: LegacyPanGesture[];
+}>("react-native-gesture-handler");
+
+/** The most recent gesture handed to `GestureDetector`, i.e. the live one. */
+const latestGesture = () => {
+  const gesture = capturedGestures.at(-1);
+
+  if (!gesture) {
+    throw new Error("MagicModal never built a Gesture.Pan()");
+  }
+
+  return gesture;
+};
+
+type Handlers = LegacyPanGesture["handlers"];
+type StateChangeEvent = Parameters<NonNullable<Handlers["onStart"]>>[0];
+type UpdateEvent = Parameters<NonNullable<Handlers["onUpdate"]>>[0];
+
+const activeEvent = () => baseEvent as unknown as StateChangeEvent;
+
+const endEvent = (velocity: { velocityX: number; velocityY: number }) =>
+  ({ ...baseEvent, ...velocity }) as unknown as StateChangeEvent;
+
+const updateEvent = (translation: {
+  translationX: number;
+  translationY: number;
+}) => ({ ...baseEvent, ...translation }) as unknown as UpdateEvent;
+
+beforeEach(() => {
+  // No `hideAll` here. The testing library unmounts the portal between tests
+  // already, and hiding into an unmounted tree makes React warn about updates
+  // outside `act`.
+  capturedGestures.length = 0;
+});
+
+describe("MagicModal swipe gesture on gesture-handler 2.x", () => {
+  it("hangs the dismissal off onEnd and leaves onFinalize alone", () => {
+    showModal("down");
+
+    const { handlers } = latestGesture();
+
+    expect(typeof handlers.onStart).toBe("function");
+    expect(typeof handlers.onUpdate).toBe("function");
+    expect(typeof handlers.onEnd).toBe("function");
+
+    // `.onFinalize` also runs for gestures that never activated: a tap that
+    // failed the slop check, or a cancelled gesture. Anything hung off it would
+    // run the dismissal on paths `.onEnd` never fired on.
+    expect(handlers.onFinalize).toBeUndefined();
+    expect(handlers.onBegin).toBeUndefined();
+  });
+
+  it("keeps the callbacks on the UI thread", () => {
+    showModal("down");
+
+    const gesture = latestGesture();
+
+    // 2.x reads `__workletHash` off each registered callback and only mounts the
+    // reanimated detector when all of them are worklets. Dropping the "worklet"
+    // directives would silently move the whole swipe onto the JS thread.
+    for (const name of ["onStart", "onUpdate", "onEnd"] as const) {
+      expect(gesture.handlers[name]).toHaveProperty("__workletHash");
+    }
+
+    // The builder records the same verdict as it goes. `shouldUseReanimated`,
+    // which reads this, can't be asserted directly: it also calls
+    // `isRemoteDebuggingEnabled()`, which is always true under jest because
+    // there is no `nativeCallSyncHook` on the global.
+    expect(gesture.handlers.isWorklet).not.toContain(false);
+  });
+
+  it("only enables the gesture when a swipeDirection is set", () => {
+    showModal("down");
+    expect(latestGesture().config.enabled).toBe(true);
+
+    capturedGestures.length = 0;
+    showModal(undefined);
+    expect(latestGesture().config.enabled).toBe(false);
+  });
+
+  it("forwards the touch slop as minDistance", () => {
+    showModal("down");
+
+    // `.minDistance()` writes through to `minDist`, which is the name the native
+    // side takes.
+    expect(latestGesture().config.minDist).toBe(expectedMinDistance);
+  });
+
+  it("keeps the same gesture object across re-renders", () => {
+    showModal("down");
+
+    const first = latestGesture();
+    const seen = capturedGestures.length;
+
+    act(() => {
+      magicModal.show(() => <ModalContent />, { swipeDirection: "down" });
+    });
+
+    // The first modal re-renders when a second one is pushed. Its gesture has to
+    // keep its identity: 2.x's `GestureDetector` compares `gestureId` to decide
+    // whether to re-push the whole gesture to the native side, and every
+    // `Gesture.Pan()` gets a fresh one.
+    expect(capturedGestures.length).toBeGreaterThan(seen);
+    expect(capturedGestures[0]).toBe(first);
+  });
+
+  it.each(directions)(
+    "resolves with SWIPE_COMPLETE when the %s swipe clears the velocity threshold",
+    async (swipeDirection) => {
+      const promise = showModal(swipeDirection);
+      const { handlers } = latestGesture();
+
+      let result: unknown;
+      void promise?.then((value) => {
+        result = value;
+      });
+
+      await act(async () => {
+        handlers.onStart?.(activeEvent());
+        handlers.onEnd?.(endEvent(fastVelocity[swipeDirection]), true);
+
+        await waitForHide(() => result !== undefined);
+      });
+
+      expect(result).toEqual({
+        reason: MagicModalHideReason.SWIPE_COMPLETE,
+      });
+    },
+  );
+
+  it.each(directions)(
+    "keeps the %s modal open when the swipe is under the velocity threshold",
+    async (swipeDirection) => {
+      const promise = showModal(swipeDirection);
+      const { handlers } = latestGesture();
+
+      let resolved = false;
+      void promise?.then(() => {
+        resolved = true;
+      });
+
+      act(() => {
+        handlers.onStart?.(activeEvent());
+        handlers.onUpdate?.(updateEvent({ translationX: 5, translationY: 5 }));
+        handlers.onEnd?.(endEvent(slowVelocity), true);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(resolved).toBe(false);
+    },
+  );
+});

--- a/packages/modal/src/components/MagicModal.swipe.v3.test.tsx
+++ b/packages/modal/src/components/MagicModal.swipe.v3.test.tsx
@@ -1,38 +1,48 @@
-import type { PanGestureConfig } from "react-native-gesture-handler";
 import React from "react";
-import { Text } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { act, render as rntlRender } from "@testing-library/react-native";
+import { act } from "@testing-library/react-native";
 
-import type { Direction } from "../constants/types";
+import type { PanGestureConfigCompat } from "./panGesture/gestureHandlerCompat";
 import { MagicModalHideReason } from "../constants/types";
 import { magicModal } from "../utils/magicModalHandler";
-import { MagicModalPortal } from "./MagicModalPortal/MagicModalPortal";
+import {
+  baseEvent,
+  directions,
+  expectedMinDistance,
+  fastVelocity,
+  ModalContent,
+  showModal,
+  slowVelocity,
+  waitForHide,
+} from "./MagicModal.swipe.harness";
 
 /**
- * The swipe gesture is the one part of the modal the public API can't drive:
- * it lives inside a gesture-handler hook and its callbacks are worklets. So we
+ * The swipe gesture is the one part of the modal the public API can't drive: it
+ * lives inside a gesture-handler hook and its callbacks are worklets. So we
  * intercept the config `MagicModal` hands to `usePanGesture` and call the
  * callbacks ourselves.
  *
- * The point of these tests is the callback *names*. gesture-handler 3.x has
- * both `onDeactivate` (what `.onEnd` used to be) and `onFinalize`, and
+ * The point of these tests is the callback *names*. gesture-handler 3.x has both
+ * `onDeactivate` (what 2.x's `.onEnd` used to be) and `onFinalize`, and
  * `onFinalize` additionally runs for gestures that never activated. Wiring the
  * dismissal to the wrong one leaves the modal looking correct in a manual test
- * while `SWIPE_COMPLETE` resolves at a different point in the gesture
- * lifecycle.
+ * while `SWIPE_COMPLETE` resolves at a different point in the gesture lifecycle.
+ *
+ * Defining `usePanGesture` in the mock also pins which surface renders:
+ * `hasPanGestureHook` reads it off the module, so this suite exercises the
+ * hook-based path whichever gesture-handler is installed. Its 2.x counterpart is
+ * `MagicModal.swipe.v2.test.tsx`.
  */
 jest.mock("react-native-gesture-handler", () => {
   const actual = jest.requireActual<Record<string, unknown>>(
     "react-native-gesture-handler",
   );
 
-  const capturedPanConfigs: PanGestureConfig[] = [];
+  const capturedPanConfigs: PanGestureConfigCompat[] = [];
 
   return {
     ...actual,
     capturedPanConfigs,
-    usePanGesture: (config: PanGestureConfig) => {
+    usePanGesture: (config: PanGestureConfigCompat) => {
       capturedPanConfigs.push(config);
       return { handlerTag: -1 };
     },
@@ -41,12 +51,8 @@ jest.mock("react-native-gesture-handler", () => {
 });
 
 const { capturedPanConfigs } = jest.requireMock<{
-  capturedPanConfigs: PanGestureConfig[];
+  capturedPanConfigs: PanGestureConfigCompat[];
 }>("react-native-gesture-handler");
-
-const content = "Taveira";
-
-const ModalContent = () => <Text testID="swipe-content">{content}</Text>;
 
 /** The most recent config handed to `usePanGesture`, i.e. the live one. */
 const latestPanConfig = () => {
@@ -59,46 +65,18 @@ const latestPanConfig = () => {
   return config;
 };
 
-const showModal = (swipeDirection: Direction | undefined) => {
-  rntlRender(
-    <GestureHandlerRootView>
-      <MagicModalPortal />
-    </GestureHandlerRootView>,
-  );
-
-  let promise: Promise<unknown> | undefined;
-
-  act(() => {
-    promise = magicModal.show(() => <ModalContent />, {
-      swipeDirection,
-    }).promise;
-  });
-
-  return promise;
-};
-
-const baseEvent = {
-  handlerTag: -1,
-  numberOfPointers: 1,
-  pointerType: 0,
-  x: 0,
-  y: 0,
-  absoluteX: 0,
-  absoluteY: 0,
-  stylusData: undefined,
-  translationX: 0,
-  translationY: 0,
-  changeX: 0,
-  changeY: 0,
-  velocityX: 0,
-  velocityY: 0,
-};
-
-type ActiveEvent = Parameters<NonNullable<PanGestureConfig["onActivate"]>>[0];
-type UpdateEvent = Parameters<
-  Extract<NonNullable<PanGestureConfig["onUpdate"]>, (event: never) => void>
+type ActiveEvent = Parameters<
+  NonNullable<PanGestureConfigCompat["onActivate"]>
 >[0];
-type EndEvent = Parameters<NonNullable<PanGestureConfig["onDeactivate"]>>[0];
+type UpdateEvent = Parameters<
+  Extract<
+    NonNullable<PanGestureConfigCompat["onUpdate"]>,
+    (event: never) => void
+  >
+>[0];
+type EndEvent = Parameters<
+  NonNullable<PanGestureConfigCompat["onDeactivate"]>
+>[0];
 
 const activeEvent = () => baseEvent as unknown as ActiveEvent;
 
@@ -106,11 +84,11 @@ const endEvent = (velocity: { velocityX: number; velocityY: number }) =>
   ({ ...baseEvent, ...velocity, canceled: false }) as unknown as EndEvent;
 
 /**
- * `onUpdate` is typed as the callback union'd with `Animated.event`, which
- * isn't callable. We only ever pass the callback form.
+ * `onUpdate` is typed as the callback union'd with `Animated.event`, which isn't
+ * callable. We only ever pass the callback form.
  */
 const runOnUpdate = (
-  config: PanGestureConfig,
+  config: PanGestureConfigCompat,
   translation: { translationX: number; translationY: number },
 ) => {
   const onUpdate = config.onUpdate as
@@ -119,15 +97,6 @@ const runOnUpdate = (
   onUpdate?.({ ...baseEvent, ...translation } as unknown as UpdateEvent);
 };
 
-const fastVelocity = {
-  up: { velocityX: 0, velocityY: -900 },
-  down: { velocityX: 0, velocityY: 900 },
-  left: { velocityX: -900, velocityY: 0 },
-  right: { velocityX: 900, velocityY: 0 },
-} satisfies Record<Direction, { velocityX: number; velocityY: number }>;
-
-const directions = ["up", "down", "left", "right"] as const;
-
 beforeEach(() => {
   // No `hideAll` here. The testing library unmounts the portal between tests
   // already, and hiding into an unmounted tree makes React warn about updates
@@ -135,7 +104,7 @@ beforeEach(() => {
   capturedPanConfigs.length = 0;
 });
 
-describe("MagicModal swipe gesture", () => {
+describe("MagicModal swipe gesture on gesture-handler 3.x", () => {
   it("hangs the dismissal off onDeactivate and leaves onFinalize alone", () => {
     showModal("down");
 
@@ -146,8 +115,8 @@ describe("MagicModal swipe gesture", () => {
     expect(typeof config.onDeactivate).toBe("function");
 
     // `onFinalize` also runs for gestures that never activated: a tap that
-    // failed the slop check, or a cancelled gesture. Anything hung off it
-    // would run the dismissal on paths `.onEnd` never fired on.
+    // failed the slop check, or a cancelled gesture. Anything hung off it would
+    // run the dismissal on paths `.onEnd` never fired on.
     expect(config.onFinalize).toBeUndefined();
     expect(config.onBegin).toBeUndefined();
   });
@@ -174,6 +143,12 @@ describe("MagicModal swipe gesture", () => {
     expect(latestPanConfig().enabled).toBe(false);
   });
 
+  it("forwards the touch slop as minDistance", () => {
+    showModal("down");
+
+    expect(latestPanConfig().minDistance).toBe(expectedMinDistance);
+  });
+
   it("keeps the same config object across re-renders", () => {
     showModal("down");
 
@@ -184,9 +159,9 @@ describe("MagicModal swipe gesture", () => {
       magicModal.show(() => <ModalContent />, { swipeDirection: "down" });
     });
 
-    // The first modal re-renders when a second one is pushed. Its config has
-    // to keep its identity: `usePanGesture` memoizes on it and re-pushes the
-    // whole config to the native side whenever it changes.
+    // The first modal re-renders when a second one is pushed. Its config has to
+    // keep its identity: `usePanGesture` memoizes on it and re-pushes the whole
+    // config to the native side whenever it changes.
     expect(capturedPanConfigs.length).toBeGreaterThan(seen);
     expect(capturedPanConfigs[0]).toBe(first);
   });
@@ -206,14 +181,7 @@ describe("MagicModal swipe gesture", () => {
         config.onActivate?.(activeEvent());
         config.onDeactivate?.(endEvent(fastVelocity[swipeDirection]));
 
-        // The dismissal spring runs for several frames and its completion
-        // callback hops from the UI thread back to JS via `scheduleOnRN`, so
-        // `hide` lands well after `onDeactivate` returns. Poll on timers, which
-        // is what drives the spring; awaiting the show promise in here instead
-        // deadlocks, because the frame loop doesn't advance inside `act`.
-        for (let i = 0; i < 100 && result === undefined; i++) {
-          await new Promise((resolve) => setTimeout(resolve, 20));
-        }
+        await waitForHide(() => result !== undefined);
       });
 
       expect(result).toEqual({
@@ -236,7 +204,7 @@ describe("MagicModal swipe gesture", () => {
       act(() => {
         config.onActivate?.(activeEvent());
         runOnUpdate(config, { translationX: 5, translationY: 5 });
-        config.onDeactivate?.(endEvent({ velocityX: 10, velocityY: 10 }));
+        config.onDeactivate?.(endEvent(slowVelocity));
       });
 
       await act(async () => {

--- a/packages/modal/src/components/MagicModal.tsx
+++ b/packages/modal/src/components/MagicModal.tsx
@@ -1,7 +1,5 @@
-import type { PanGestureConfig } from "react-native-gesture-handler";
 import React, { memo, useMemo } from "react";
 import { Pressable, StyleSheet, useWindowDimensions, View } from "react-native";
-import { GestureDetector, usePanGesture } from "react-native-gesture-handler";
 import Animated, {
   Extrapolation,
   FadeIn,
@@ -22,10 +20,12 @@ import Animated, {
 import { scheduleOnRN } from "react-native-worklets";
 
 import type { Direction, ModalChildren, ModalProps } from "../constants/types";
+import type { SwipeGestureSpec } from "./panGesture";
 import { defaultDirection } from "../constants/defaultConfig";
 import { MagicModalHideReason } from "../constants/types";
 import { styles } from "./MagicModalPortal/MagicModalPortal.styles";
 import { useInternalMagicModal } from "./MagicModalProvider";
+import { PanGestureSurface } from "./panGesture";
 
 export const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -94,29 +94,23 @@ export const MagicModal = memo(
     );
 
     /**
-     * `usePanGesture` memoizes on the identity of the config object it is
-     * handed, and re-pushes the whole config to the native side whenever that
-     * identity changes. Building the object inline would do that on every
-     * render, so it lives in a `useMemo` keyed on everything the worklets
-     * close over.
+     * Both swipe surfaces re-push the whole gesture to the native side when
+     * this object's identity changes, so it lives in a `useMemo` keyed on
+     * everything the worklets close over.
      *
-     * The callback names are gesture-handler v3's. The v2 builder equivalents
-     * were `.onStart` (`onActivate`), `.onUpdate` (`onUpdate`) and `.onEnd`
-     * (`onDeactivate`). `onDeactivate` is deliberate: it is the callback wired
-     * to `CALLBACK_TYPE.END`, which is what `.onEnd` registered, so
-     * `SWIPE_COMPLETE` still resolves at the same point in the gesture
-     * lifecycle. `onFinalize` (`CALLBACK_TYPE.FINALIZE`) also runs after
-     * gestures that never activated, and using it here would fire the
-     * dismissal spring on taps that failed the slop check.
+     * The callback names are gesture-handler 2.x's, and `PanGestureSurface`
+     * maps them to whichever API the installed major exposes. See
+     * `panGesture/PanGestureSurface.types.ts` for the mapping and for why
+     * nothing hangs off `onFinalize`.
      */
-    const panConfig = useMemo<PanGestureConfig>(
+    const swipe = useMemo<SwipeGestureSpec>(
       () => ({
         enabled: !!config.swipeDirection,
         // Matches the platform touch slop. Anything smaller (we used to use 1)
         // lets finger jitter during a tap activate the pan, which cancels the
         // touch on whatever the user was actually pressing inside the modal.
         minDistance: TOUCH_SLOP,
-        onActivate: () => {
+        onStart: () => {
           "worklet";
 
           prevTranslationX.value = translationX.value;
@@ -153,7 +147,7 @@ export const MagicModal = memo(
             translationY.value = dampedTranslation;
           }
         },
-        onDeactivate: (event) => {
+        onEnd: (event) => {
           "worklet";
 
           const velocityThreshold = config.swipeVelocityThreshold;
@@ -222,8 +216,6 @@ export const MagicModal = memo(
         translationY,
       ],
     );
-
-    const pan = usePanGesture(panConfig);
 
     const animatedStyles = useAnimatedStyle(() => {
       "worklet";
@@ -298,7 +290,7 @@ export const MagicModal = memo(
                 : undefined
             }
           >
-            <GestureDetector gesture={pan}>
+            <PanGestureSurface swipe={swipe}>
               <View
                 collapsable={false}
                 style={[
@@ -309,7 +301,7 @@ export const MagicModal = memo(
               >
                 <Children />
               </View>
-            </GestureDetector>
+            </PanGestureSurface>
           </Animated.View>
         </Animated.View>
       </View>

--- a/packages/modal/src/components/panGesture/PanGestureSurface.test.ts
+++ b/packages/modal/src/components/panGesture/PanGestureSurface.test.ts
@@ -1,0 +1,86 @@
+/**
+ * `PanGestureSurface` resolves once, when this module first loads, from whether
+ * the installed gesture-handler exports `usePanGesture`. That has to happen at
+ * module scope: a branch inside a component would mean calling the hook
+ * conditionally, and React would see the hook order change.
+ *
+ * The two swipe suites each pin a surface through their own mock so they cover
+ * both wirings on any installed major, which leaves the detection itself
+ * uncovered. This is where it's covered. Each case reloads the module graph in a
+ * fresh registry, because the constant is read exactly once per process.
+ */
+
+interface IsolatedModules {
+  picked: unknown;
+  v2: unknown;
+  v3: unknown;
+  hasPanGestureHook: boolean;
+}
+
+/**
+ * The surfaces have to come out of the same registry as `PanGestureSurface`
+ * itself, otherwise the identity comparison is meaningless: every reload
+ * produces fresh function objects.
+ */
+const load = <T>(modulePath: string): T => require(modulePath) as T;
+
+const loadWith = (gestureHandlerOverrides: Record<string, unknown>) => {
+  let loaded: IsolatedModules | undefined;
+
+  jest.isolateModules(() => {
+    jest.doMock("react-native-gesture-handler", () => ({
+      ...jest.requireActual<Record<string, unknown>>(
+        "react-native-gesture-handler",
+      ),
+      ...gestureHandlerOverrides,
+    }));
+
+    const { PanGestureSurface } = load<{ PanGestureSurface: unknown }>(
+      "./index",
+    );
+    const { PanGestureSurfaceV2 } = load<{ PanGestureSurfaceV2: unknown }>(
+      "./PanGestureSurface.v2",
+    );
+    const { PanGestureSurfaceV3 } = load<{ PanGestureSurfaceV3: unknown }>(
+      "./PanGestureSurface.v3",
+    );
+    const { hasPanGestureHook } = load<{ hasPanGestureHook: boolean }>(
+      "./gestureHandlerCompat",
+    );
+
+    loaded = {
+      picked: PanGestureSurface,
+      v2: PanGestureSurfaceV2,
+      v3: PanGestureSurfaceV3,
+      hasPanGestureHook,
+    };
+  });
+
+  if (!loaded) {
+    throw new Error("isolateModules never ran");
+  }
+
+  return loaded;
+};
+
+describe("PanGestureSurface", () => {
+  it("picks the hook surface when gesture-handler exports usePanGesture", () => {
+    const { picked, v3, hasPanGestureHook } = loadWith({
+      usePanGesture: () => ({ handlerTag: -1 }),
+    });
+
+    expect(hasPanGestureHook).toBe(true);
+    expect(picked).toBe(v3);
+  });
+
+  it("falls back to the builder surface when it doesn't", () => {
+    // What a gesture-handler 2.x install looks like: no `usePanGesture` at the
+    // package root at all.
+    const { picked, v2, hasPanGestureHook } = loadWith({
+      usePanGesture: undefined,
+    });
+
+    expect(hasPanGestureHook).toBe(false);
+    expect(picked).toBe(v2);
+  });
+});

--- a/packages/modal/src/components/panGesture/PanGestureSurface.types.ts
+++ b/packages/modal/src/components/panGesture/PanGestureSurface.types.ts
@@ -1,0 +1,38 @@
+/**
+ * The event fields the swipe worklets read, and nothing else. Both
+ * gesture-handler majors hand their pan callbacks an event carrying these, so
+ * typing the worklets this narrowly lets one set of them drive either API.
+ */
+export interface SwipeTranslationEvent {
+  translationX: number;
+  translationY: number;
+}
+
+export interface SwipeVelocityEvent {
+  velocityX: number;
+  velocityY: number;
+}
+
+/**
+ * What `MagicModal` needs from a pan gesture, spelled out independently of
+ * gesture-handler's major version.
+ *
+ * The callback names follow gesture-handler 2.x's builder, and each surface
+ * maps them to its own API. The mapping is `onStart` -> 3.x `onActivate`,
+ * `onUpdate` -> 3.x `onUpdate`, `onEnd` -> 3.x `onDeactivate`. Nothing maps to
+ * `onFinalize` or `onBegin`: both also run for gestures that never activated,
+ * so hanging the dismissal off either would fire it on taps that failed the
+ * slop check.
+ */
+export interface SwipeGestureSpec {
+  enabled: boolean;
+  minDistance: number;
+  onStart: () => void;
+  onUpdate: (event: SwipeTranslationEvent) => void;
+  onEnd: (event: SwipeVelocityEvent) => void;
+}
+
+export interface PanGestureSurfaceProps {
+  swipe: SwipeGestureSpec;
+  children: React.ReactNode;
+}

--- a/packages/modal/src/components/panGesture/PanGestureSurface.v2.tsx
+++ b/packages/modal/src/components/panGesture/PanGestureSurface.v2.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from "react";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+
+import type { PanGestureSurfaceProps } from "./PanGestureSurface.types";
+
+/**
+ * The gesture object `Gesture.Pan()` builds. Derived from the builder rather
+ * than imported by name because the name moved: 2.x exports it as `PanGesture`,
+ * and in 3.x that name belongs to the hook API's gesture instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- v2 compat
+export type LegacyPanGesture = ReturnType<typeof Gesture.Pan>;
+
+/**
+ * Swipe surface for gesture-handler 2.x, built on the `Gesture.Pan()` builder.
+ *
+ * 2.x's `GestureDetector` compares `gestureId` to decide whether to re-push the
+ * gesture to the native side, and every `Gesture.Pan()` gets a fresh one, so
+ * the builder is memoized on the spec rather than rebuilt each render.
+ */
+export const PanGestureSurfaceV2 = ({
+  swipe,
+  children,
+}: PanGestureSurfaceProps) => {
+  const pan = useMemo(
+    () =>
+      // `Gesture.Pan()` is the only swipe API gesture-handler 2.x has, and 3.x
+      // marks the builder deprecated. The rule fires because this repo builds
+      // against 3.x; the call is what keeps 2.x, and so every current Expo SDK,
+      // working. Suppressed here rather than in the config: any *other*
+      // deprecated call in this package should still be an error.
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- v2 compat
+      Gesture.Pan()
+        .enabled(swipe.enabled)
+        .minDistance(swipe.minDistance)
+        .onStart(swipe.onStart)
+        .onUpdate(swipe.onUpdate)
+        // Not `.onFinalize`: it also runs after gestures that never activated,
+        // which would fire the dismissal spring on taps inside the modal.
+        .onEnd(swipe.onEnd),
+    [swipe],
+  );
+
+  return <GestureDetector gesture={pan}>{children}</GestureDetector>;
+};

--- a/packages/modal/src/components/panGesture/PanGestureSurface.v3.tsx
+++ b/packages/modal/src/components/panGesture/PanGestureSurface.v3.tsx
@@ -23,10 +23,10 @@ export const PanGestureSurfaceV3 = ({
       minDistance: swipe.minDistance,
       onActivate: swipe.onStart,
       onUpdate: swipe.onUpdate,
-      // `CALLBACK_TYPE.END`, which is what 2.x's `.onEnd` registered, so
-      // SWIPE_COMPLETE resolves at the same point in the gesture lifecycle on
-      // both majors. `onFinalize` would additionally run after gestures that
-      // never activated.
+      // `onDeactivate` is wired to `CALLBACK_TYPE.END`, which is what 2.x's
+      // `.onEnd` registered, so SWIPE_COMPLETE resolves at the same point in
+      // the gesture lifecycle on both majors. `onFinalize` would additionally
+      // run after gestures that never activated.
       onDeactivate: swipe.onEnd,
     }),
     [swipe],

--- a/packages/modal/src/components/panGesture/PanGestureSurface.v3.tsx
+++ b/packages/modal/src/components/panGesture/PanGestureSurface.v3.tsx
@@ -1,0 +1,38 @@
+import React, { useMemo } from "react";
+import { GestureDetector } from "react-native-gesture-handler";
+
+import type { PanGestureConfigCompat } from "./gestureHandlerCompat";
+import type { PanGestureSurfaceProps } from "./PanGestureSurface.types";
+import { usePanGestureCompat } from "./gestureHandlerCompat";
+
+/**
+ * Swipe surface for gesture-handler 3.x, built on the `usePanGesture` hook.
+ *
+ * `usePanGesture` memoizes on the identity of the config object it is handed
+ * and re-pushes the whole config to the native side whenever that identity
+ * changes. Building the object inline would do that on every render, so it is
+ * memoized on the spec, which `MagicModal` already keeps stable.
+ */
+export const PanGestureSurfaceV3 = ({
+  swipe,
+  children,
+}: PanGestureSurfaceProps) => {
+  const panConfig = useMemo<PanGestureConfigCompat>(
+    () => ({
+      enabled: swipe.enabled,
+      minDistance: swipe.minDistance,
+      onActivate: swipe.onStart,
+      onUpdate: swipe.onUpdate,
+      // `CALLBACK_TYPE.END`, which is what 2.x's `.onEnd` registered, so
+      // SWIPE_COMPLETE resolves at the same point in the gesture lifecycle on
+      // both majors. `onFinalize` would additionally run after gestures that
+      // never activated.
+      onDeactivate: swipe.onEnd,
+    }),
+    [swipe],
+  );
+
+  const pan = usePanGestureCompat(panConfig);
+
+  return <GestureDetector gesture={pan}>{children}</GestureDetector>;
+};

--- a/packages/modal/src/components/panGesture/gestureHandlerCompat.ts
+++ b/packages/modal/src/components/panGesture/gestureHandlerCompat.ts
@@ -1,0 +1,99 @@
+import type {
+  GestureStateChangeEvent,
+  GestureUpdateEvent,
+  PanGestureHandlerEventPayload,
+} from "react-native-gesture-handler";
+// A namespace import is the only way to read an export that might not be there.
+// `import { usePanGesture }` is a hard error on gesture-handler 2.x, both when
+// typechecking and, under a real ESM loader, at runtime.
+import * as GestureHandler from "react-native-gesture-handler";
+
+type GestureHandlerModule = typeof GestureHandler;
+
+/**
+ * Stands in for gesture-handler 3.x's `PanGestureConfig` when the installed
+ * gesture-handler is 2.x and the real type does not exist. It only lists what
+ * `MagicModal` reads or writes.
+ *
+ * On 3.x, `PanGestureConfigCompat` below resolves to the type the installed
+ * `usePanGesture` actually accepts, so a rename upstream breaks `tsc` instead
+ * of the app.
+ */
+interface FallbackPanGestureConfig {
+  enabled?: boolean;
+  minDistance?: number;
+  onBegin?: (
+    event: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
+  ) => void;
+  onActivate?: (
+    event: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
+  ) => void;
+  onUpdate?:
+    | ((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => void)
+    // 3.x's `onUpdate` also takes an `Animated.event` object, which is not
+    // callable. Kept in the union so anything reading `onUpdate` has to narrow
+    // it the same way on both majors.
+    | AnimatedEventStandIn;
+  onDeactivate?: (
+    event: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
+  ) => void;
+  onFinalize?: (
+    event: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
+  ) => void;
+}
+
+interface AnimatedEventStandIn {
+  _argMapping: unknown[];
+}
+
+/** gesture-handler 3.x's `PanGestureConfig`, or the fallback above on 2.x. */
+export type PanGestureConfigCompat = GestureHandlerModule extends {
+  usePanGesture: (config?: infer Config) => unknown;
+}
+  ? NonNullable<Config>
+  : FallbackPanGestureConfig;
+
+/**
+ * gesture-handler 3.x's `PanGesture`, or `never` on 2.x. `never` is assignable
+ * to 2.x's `GestureDetector["gesture"]`, so the hook-based surface still
+ * typechecks against a major that can never render it.
+ */
+type PanGestureCompat = GestureHandlerModule extends {
+  usePanGesture: (...args: never[]) => infer Gesture;
+}
+  ? Gesture
+  : never;
+
+type UsePanGesture = (config: PanGestureConfigCompat) => PanGestureCompat;
+
+/**
+ * Plain assignment rather than a cast: on 3.x this only compiles if the real
+ * hook matches the signature above, and on 2.x the property is simply absent.
+ *
+ * `GestureDetector` is only here as an anchor. A target whose every property is
+ * optional is a weak type, and TypeScript rejects assignments to weak types that
+ * share no properties with the source, which is exactly the 2.x case.
+ */
+const gestureHandler: Pick<GestureHandlerModule, "GestureDetector"> & {
+  usePanGesture?: UsePanGesture;
+} = GestureHandler;
+
+/**
+ * True on gesture-handler 3.x. `usePanGesture` is exported from the package
+ * root there (`src/index.ts` re-exports `./v3`) and does not exist in 2.x.
+ *
+ * Read once, at module scope. The installed gesture-handler cannot change
+ * during a process lifetime, so anything downstream can treat this as a
+ * constant, which is what keeps hook order stable.
+ */
+export const hasPanGestureHook =
+  typeof gestureHandler.usePanGesture === "function";
+
+const missingPanGestureHook = (): never => {
+  throw new Error(
+    "react-native-magic-modal called usePanGesture, which requires react-native-gesture-handler 3.x. This is a bug: the hook-based swipe surface should only render when hasPanGestureHook is true.",
+  );
+};
+
+export const usePanGestureCompat: UsePanGesture =
+  gestureHandler.usePanGesture ?? missingPanGestureHook;

--- a/packages/modal/src/components/panGesture/index.ts
+++ b/packages/modal/src/components/panGesture/index.ts
@@ -1,0 +1,25 @@
+import { hasPanGestureHook } from "./gestureHandlerCompat";
+import { PanGestureSurfaceV2 } from "./PanGestureSurface.v2";
+import { PanGestureSurfaceV3 } from "./PanGestureSurface.v3";
+
+export type {
+  PanGestureSurfaceProps,
+  SwipeGestureSpec,
+} from "./PanGestureSurface.types";
+
+/**
+ * The swipe surface for the installed gesture-handler.
+ *
+ * 3.x replaced the `Gesture.Pan()` builder with the `usePanGesture` hook. The
+ * peer range spans both majors because Expo's SDK pin trails gesture-handler's
+ * latest, so both have to work.
+ *
+ * Picking the component here rather than branching inside one keeps hook order
+ * stable: `hasPanGestureHook` is decided once when this module first loads and
+ * cannot change afterwards, so React always sees the same component type. A
+ * branch inside a single component would mean calling `usePanGesture`
+ * conditionally.
+ */
+export const PanGestureSurface = hasPanGestureHook
+  ? PanGestureSurfaceV3
+  : PanGestureSurfaceV2;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,7 +174,7 @@ importers:
         specifier: '>=18.0.0'
         version: 19.2.0
       react-native-gesture-handler:
-        specifier: '>=3.0.0'
+        specifier: '>=2.20.0'
         version: 3.1.0(react-native@0.83.6(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       react-native-reanimated:
         specifier: '>=4.0.0'


### PR DESCRIPTION
## Why

8.0.0 moved swipe-to-dismiss onto gesture-handler 3.x's `usePanGesture` and raised the peer floor to `>=3.0.0`. No Expo SDK bundles 3.x, including the newest:

| Expo SDK | gesture-handler pin |
| --- | --- |
| 55.0.28 | `~2.30.0` |
| 56.0.17 | `~2.31.1` |
| 57.0.8 (latest) | `~2.32.0` |

gesture-handler's own dist-tags are `latest: 3.1.0`, `legacy: 2.32.0`. A managed-workflow app has no SDK it can move to that satisfies the floor. `npx expo install` pulls 2.x, `expo-doctor` reports a major mismatch, and the only way through is the `expo.install.exclude` workaround #241 added to the example.

## What changed

The swipe surface picks between the two gesture APIs once, when the module first loads, on whether the installed gesture-handler exports `usePanGesture`. 3.x gets the hook, 2.x gets `Gesture.Pan()`. The peer floor goes back to `>=2.20.0`, the value 7.x shipped with.

Two components rather than one with a branch inside it. `hasPanGestureHook` can't change during a process lifetime, so selecting a component type off it is safe; calling `usePanGesture` conditionally inside one component is not.

`MagicModal` builds one `SwipeGestureSpec` and hands it to whichever surface was picked. The worklets are shared, typed against only the event fields they read, which both majors' pan events carry. Callback mapping is exactly what 8.0.0 established: `.onStart` -> `onActivate`, `.onUpdate` -> `onUpdate`, `.onEnd` -> `onDeactivate`. Nothing hangs off `onFinalize` on either path, because it also runs for gestures that never activated and would fire the dismissal on a tap that failed the slop check.

On types: `PanGestureConfigCompat` resolves to the real `PanGestureConfig` of the installed `usePanGesture` on 3.x, and to a local stand-in only on 2.x where the real type doesn't exist. A rename upstream still breaks `tsc` here. On 3.1.0 a 3.x-only key (`activateAfterLongPress`) compiles, and a typo'd `onActivat` errors with `does not exist in type 'PanGestureConfig'`. No `any` anywhere, and `dist/index.d.ts` doesn't reference gesture-handler at all, so consumers never typecheck against either version's internals.

This is a `feat` and a minor. 8.0.0 behaves exactly as documented for anyone already on 3.x, and this adds a second supported major while widening a peer range.

## Testing

`MagicModal.swipe.v2.test.tsx` is the counterpart to #241's swipe suite, which is renamed to `MagicModal.swipe.v3.test.tsx`. Same assertions in the same order, shared scaffolding in `MagicModal.swipe.harness.tsx`. The v2 suite builds a real `Gesture.Pan()` and stubs only `GestureDetector`, which doubles as the interception point: the callbacks and config land on the gesture object itself, which is where gesture-handler's own dispatcher reads them from. `PanGestureSurface.test.ts` covers the detection, which the two suites pin with their mocks.

Full suite on both majors:

| | 3.1.0 | 2.32.0 | 2.30.1 (SDK 55's pin) | 2.20.0 (the floor) |
| --- | --- | --- | --- | --- |
| `tsc --noEmit` | clean | clean | clean | clean |
| `jest` | 36/36 | 36/36 | 36/36 | 36/36 |
| `eslint --max-warnings 0` | clean | 2 warnings | 2 warnings | 2 warnings |
| `bunchee` | ok | ok | ok | ok |
| `expo-doctor` | 19/19 (with exclude) | n/a | 19/19 (no exclude) | n/a |

Both lint warnings on 2.x are `Unused eslint-disable directive` for the `@typescript-eslint/no-deprecated` suppressions on the `Gesture.Pan()` path. `Gesture` isn't deprecated on 2.x, so on a 2.x install those suppressions have nothing to suppress. CI runs on the committed lockfile's 3.1.0, where both are live.

![Full suite green on gesture-handler 3.1.0, 2.32.0 and 2.20.0](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/suite-both-majors.png)

Raw output: [3.1.0](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/verify-gh-3.1.0.txt), [2.32.0](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/verify-gh-2.32.0.txt), [2.20.0](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/verify-gh-2.20.0.txt), and the mutation runs [3.1.0](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/mutations-gh-3.1.0.txt), [2.32.0](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/mutations-gh-2.32.0.txt).

Mutation results, identical on both majors:

| Mutation | Tests failed |
| --- | --- |
| v2 `.onEnd(swipe.onEnd)` -> `.onFinalize(...)` | 6 |
| v3 `onDeactivate: swipe.onEnd` -> `onFinalize: ...` | 6 |
| v2 `.onStart` -> `.onBegin` | 2 |
| v3 `onActivate` -> `onBegin` | 2 |
| v2 `.minDistance(swipe.minDistance)` -> `.minDistance(1)` | 1 |
| v3 `minDistance: swipe.minDistance` -> `1` | 1 |
| v2 `.enabled(swipe.enabled)` -> `.enabled(true)` | 1 |
| v3 `enabled: swipe.enabled` -> `true` | 1 |
| invert `hasPanGestureHook` in the surface picker | 28 on 3.1.0, 36 on 2.32.0 |

## Proof

Swipe-dismiss in all four directions on a gesture-handler 2.30.1 install. iPhone 17 Pro simulator, Release build, `RNGestureHandler (2.30.1)` in `Podfile.lock`. Each direction reports `SWIPE_COMPLETE`, which is what separates a completed swipe from a backdrop tap or a stray `hide()`.

<p>
  <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/swipe-2x-all-four-reasons.png" height="520" alt="Swipe harness on a 2.30.1 build reporting SWIPE_COMPLETE for up, down, left and right" />
  <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/swipe-2x-proof.gif" height="520" alt="All four swipes running on a gesture-handler 2.30.1 build" />
</p>

Also on the branch: [mp4](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/swipe-2x-proof.mp4), and the per-direction stills [up](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/after-up-2x.png), [down](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/after-down-2x.png), [left](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/gesture-handler-dual/after-left-2x.png).

The 3.x direction proof from #241 is still valid and lives under `issue-221/` on the same branch.

Driven through the `swipe.tsx` harness by coordinates. On iOS 26 + RN 0.83, XCUITest reports the whole RN root as one opaque accessibility element, so nothing in the tree is reachable by text or testID. #241 hit the same thing, and it's why the four `swipe-dismiss-*.yaml` flows stay out of the CI matrix.

## Docs

README: peer table back to 2.20.0, both majors documented, `expo.install.exclude` advice gone. Replaced with the fact that there's nothing to do on Expo now. The docs site is typedoc over this README, so it picks the change up on merge.

## Example pin

The `expo.install.exclude` entry stays in `examples/kitchen-sink`, which reads odd next to a README telling consumers to drop theirs. It stays because the example pins the workspace's gesture-handler, so it decides what CI typechecks and lints against.

3.x still ships the entire 2.x builder API, so linting and typechecking against 3.x covers both paths, including the real `PanGestureConfig` check and the deprecation suppressions. 2.x ships nothing of 3.x, so an example on 2.x would leave the hook path with no real types to check against, and it would stay that way: `renovate.json` pins the example's runtime deps to `in-range-only`, so nothing would ever move it back to 3.x on its own.

A nested devDependency in `packages/modal` would give both, and it doesn't work. I tried it: pnpm nests the second copy and `expo-doctor` fails the required check on `Found duplicates for react-native-gesture-handler`. `renovate.json` already documents the same trap for `react-native`.

With the example on `~2.30.0` and no gesture-handler entry in `expo.install.exclude`, `expo-doctor` is 19/19 clean. That's the state the simulator proof above was captured in, and it's the evidence for the README dropping the workaround.

One unrelated fix came along. `jest.config.js` pointed `setupFiles` at `../../node_modules/react-native-gesture-handler/jestSetup.js`, which assumes hoisting; it's the bare module path now so it follows normal resolution. That's what made the multi-version runs trustworthy, since the two majors ship different `jestSetup.js` files.

Follow-up to #241 / #221.
