### PR TITLE
chore(ci): give branch-validation and e2e-ios explicit token scopes

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
 
+# Reads the tree and nothing else. The pnpm and turbo caches go through the
+# Actions cache service on the runtime token.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -7,6 +7,10 @@ on:
       - main
     types: [opened, reopened, synchronize, ready_for_review]
 
+# Default for both jobs. The approval gate widens it by one scope.
+permissions:
+  contents: read
+
 concurrency:
   # Key off the PR number (works across pull_request and pull_request_review
   # events). Falls back to ref for direct pushes / re-runs.
@@ -21,6 +25,10 @@ jobs:
   approval-gate:
     name: 🔐 Approval gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Reads the PR's review list.
+      pull-requests: read
     outputs:
       approved: ${{ steps.check.outputs.approved }}
     steps:


### PR DESCRIPTION
The repo hands every workflow a `write` GITHUB_TOKEN by default. Flipping that to `read` needs these two workflows to say what they use first, because neither declares `permissions:` at all, so they'd drop to read-only.

`branch-validation.yml` only reads the tree. The pnpm and turbo caches go through the Actions cache service on the runtime token. `contents: read`.

`e2e-ios.yml` is the same except for the approval gate, which reads `repos/{repo}/pulls/{n}/reviews` to decide whether to spend a macOS runner. That job gets `pull-requests: read` on top; the workflow default covers the rest.

The other two already declare and don't change. `docs.yml` has `contents: read`, `pages: write`, `id-token: write` at workflow level for the Pages deploy. `release.yml` has `contents: write`, `pull-requests: write`, `actions: write` on the job, which it needs to push the sync branch, open the PR and approve the parked run.

Once this is on main I'll set `default_workflow_permissions` to `read` via the API, keeping `can_approve_pull_request_reviews: true`, and prove all four still pass under it.
