### PR TITLE
chore(ci): move three more actions to their node 24 majors

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 
@@ -85,9 +85,12 @@ jobs:
         run: pnpm run docs
 
       - name: 📩 Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "./packages/modal/docs"
+          # typedoc writes a .nojekyll into the output. v4 stopped bundling
+          # dotfiles by default, so without this the deployed site loses it.
+          include-hidden-files: true
 
       - name: 🚀 Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -101,7 +101,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -246,7 +246,7 @@ jobs:
 
       - name: 📤 Upload Maestro debug output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maestro-debug-output
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 


### PR DESCRIPTION
setup-node v4 -> v7, upload-artifact v4 -> v7, upload-pages-artifact v3 -> v5. Three node 24 runtime moves. That leaves `pnpm/action-setup` and the turbo caching action on node 20. One branch again, same reason as #251.

## setup-node

I held this one back from #251 because v5 added automatic caching driven by the `packageManager` field, which this repo has at the root, and layering that under the explicit `actions/cache` store steps looked like trouble. v7's `action.yml` puts the trigger narrower than I assumed: caching turns on "when either `devEngines.packageManager` or the top-level `packageManager` field in package.json specifies npm". This repo says `pnpm@10.34.5`, so it never fires. `e2e-ios.yml` asks for `cache: pnpm` explicitly and is unaffected either way.

v7's one removed input is `always-auth`. Nothing under `.github/` passes it. The rest of the diff from v6 is the `cache-primary-key` and `cache-matched-key` outputs, both new.

## upload-artifact

v7 adds one input, `archive`, defaulting to `true`, which is what v4 did unconditionally. Every input `e2e-ios.yml` passes is unchanged.

## upload-pages-artifact

This one changes behaviour. v4 stopped bundling dotfiles: the tar step takes `--exclude=.[^/]*` unless you opt out. typedoc writes a `.nojekyll` into `packages/modal/docs`, and https://gstj.github.io/react-native-magic-modal/.nojekyll returns 200 today, so the bare bump would drop it off the deployed site. v5 added `include-hidden-files`, so the step sets it and the artifact stays what v3 shipped.

Pages deploys from Actions don't run Jekyll, so the file isn't doing anything visible either way.

## Checks

[Branch Checkup](https://github.com/GSTJ/react-native-magic-modal/actions/runs/30239968215) and [E2E iOS](https://github.com/GSTJ/react-native-magic-modal/actions/runs/30239968266), both green, the latter through the Release build, both Maestro flows, `upload-artifact@v7` and all three cache saves.

First PR under the read-only default token from #265, so it also stands as the check that Branch Checkup and the iOS E2E run on `contents: read`. The `Setup Node` step logs `package-manager-cache: true` and restores nothing, which is the pnpm-not-npm behaviour above. The node 20 deprecation warning is down to `pnpm/action-setup` and the turbo caching action.

Supersedes #253, #254 and #258.
