### PR TITLE
fix(ci): take includeIgnoreFile from @eslint/config-helpers

### DIFF
--- a/examples/kitchen-sink/eslint.config.js
+++ b/examples/kitchen-sink/eslint.config.js
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { includeIgnoreFile } from "@eslint/compat";
+import { includeIgnoreFile } from "@eslint/config-helpers";
 import reactNativeConfig from "magic-eslint-config/react-native";
 
 /** @type {import('typescript-eslint').Config} */

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -23,7 +23,7 @@
     ]
   },
   "dependencies": {
-    "@eslint/compat": "^1.2.8",
+    "@eslint/config-helpers": "^0.7.0",
     "@next/eslint-plugin-next": "^15.3.3",
     "@shopify/eslint-plugin": "^48.0.2",
     "eslint": "^9.28.0",

--- a/packages/modal/eslint.config.js
+++ b/packages/modal/eslint.config.js
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { includeIgnoreFile } from "@eslint/compat";
+import { includeIgnoreFile } from "@eslint/config-helpers";
 import reactNativeConfig from "magic-eslint-config/react-native";
 
 /** @type {import('typescript-eslint').Config} */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,9 +97,9 @@ importers:
 
   packages/eslint-config:
     dependencies:
-      '@eslint/compat':
-        specifier: ^1.2.8
-        version: 1.4.1(eslint@9.39.5(jiti@2.7.0))
+      '@eslint/config-helpers':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@next/eslint-plugin-next':
         specifier: ^15.3.3
         version: 15.5.22
@@ -839,15 +839,6 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/compat@1.4.1':
-    resolution: {integrity: sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.40 || 9
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-
   '@eslint/config-array@0.21.2':
     resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -856,9 +847,17 @@ packages:
     resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/core@0.17.0':
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/eslintrc@3.3.6':
     resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
@@ -7746,12 +7745,6 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@1.4.1(eslint@9.39.5(jiti@2.7.0))':
-    dependencies:
-      '@eslint/core': 0.17.0
-    optionalDependencies:
-      eslint: 9.39.5(jiti@2.7.0)
-
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
@@ -7764,7 +7757,15 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
 
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
   '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
 


### PR DESCRIPTION
#262 bumps `@eslint/compat` to v2 and Branch Checkup fails on it: v2 marks `includeIgnoreFile` deprecated, `magic-eslint-config` runs `strictTypeChecked` so `@typescript-eslint/no-deprecated` is an error, and `packages/modal` lints with `--max-warnings 0`. Both `eslint.config.js` files hit it.

`includeIgnoreFile` is the only thing this repo ever imported from `@eslint/compat`, so this drops the package and takes the function from `@eslint/config-helpers`, where it moved.

The deprecation text says the function is "also available at `eslint/config`", which isn't true on eslint 9.39.5: that entry point exports `defineConfig` and `globalIgnores` and nothing else. `@eslint/config-helpers` arrives transitively through eslint at 0.4.2, which predates the move, so `magic-eslint-config` declares `^0.7.0` directly.

## Equivalence

`includeIgnoreFile` from `@eslint/compat@1.4.1` and from `@eslint/config-helpers@0.7.0`, both given this repo's `.gitignore`, return objects that are identical under `JSON.stringify`, down to the same 57 ignore patterns. [The check](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/eslint-config-helpers/include-ignore-file-equivalence.txt).

`@eslint/config-helpers@0.7.0` wants node `^20.19.0 || ^22.13.0 || >=24` and declares no peer. `.nvmrc` is 22.23.

Closes #262.
