### PR TITLE
chore(ci): pin @babel/core and @expo/metro-runtime to the Expo SDK line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,12 +13,17 @@
     {
       "description": "The example app's runtime versions are dictated by the installed Expo SDK, and expo-doctor fails the build when they drift. Refresh the lockfile inside the declared ranges, never widen them. SDK jumps are done by hand.",
       "matchFileNames": ["examples/kitchen-sink/package.json"],
-      "matchDepTypes": ["dependencies"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
       "rangeStrategy": "in-range-only"
     },
     {
-      "description": "Metro is pinned to whatever line React Native ships with, same reason.",
-      "matchPackageNames": ["metro", "metro-config", "metro-resolver"],
+      "description": "Metro is pinned to whatever line React Native ships with, same reason. @expo/metro-runtime rides the Expo SDK and is held at the SDK version by a pnpm-workspace.yaml override, which the file rule above doesn't reach.",
+      "matchPackageNames": [
+        "metro",
+        "metro-config",
+        "metro-resolver",
+        "@expo/metro-runtime"
+      ],
       "rangeStrategy": "in-range-only"
     },
     {


### PR DESCRIPTION
`renovate.json` puts two more things under the Expo SDK pin: `devDependencies` in `examples/kitchen-sink/package.json`, and `@expo/metro-runtime` by name.

Both came out of PRs that expo-doctor failed. #259 raised `@babel/core` to v8 where SDK 55 wants `^7.26.0`, and the kitchen-sink rule matched `dependencies` only while `@babel/core` sits in `devDependencies` there.

#263 raised `@expo/metro-runtime` to v57. That one is a dependency and was already covered, but an override in `pnpm-workspace.yaml` also holds it at `55.0.12`, and `matchFileNames` doesn't reach that file. The metro rule now pins it by name, for the reason that rule already gives.

Both closed. They can come back when the example moves off SDK 55, by hand.
