### PR TITLE
fix(ci): retry the CI-opened PR when no pull_request run appears

### DIFF
--- a/.github/actions/approve-parked-ci/action.yml
+++ b/.github/actions/approve-parked-ci/action.yml
@@ -1,16 +1,16 @@
 name: Approve parked CI
 description: >
-  Releases the pull_request runs that GitHub parks at conclusion
-  action_required when a PR is opened with GITHUB_TOKEN. The ruleset on main
-  only reads checks attached to the PR, so a parked run leaves the PR unable to
-  merge. GITHUB_TOKEN is allowed to approve a run it triggered.
+  Gets the pull_request runs a CI-opened PR needs onto the PR. GitHub parks
+  them at conclusion action_required when the PR is opened with GITHUB_TOKEN,
+  and sometimes creates none at all. Either way the ruleset on main sees no
+  check and the PR sits unmergeable.
 
 inputs:
   pull-request:
     description: Number of the pull request whose runs should be released.
     required: true
   token:
-    description: Token with actions:write on this repository.
+    description: Token with actions:write and pull-requests:write on this repository.
     required: true
 
 runs:
@@ -23,30 +23,65 @@ runs:
       run: |
         set -euo pipefail
 
-        sha=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)
-        echo "pull request #$PR is at $sha"
+        runs_for() {
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$1" \
+            --jq '.workflow_runs[] | "\(.id) \(.conclusion // "none")"'
+        }
 
-        # The runs show up after the PR does, so poll for them and approve
-        # every parked one. Both Branch Checkup and the iOS E2E trigger on
-        # pull_request, so there's more than one.
-        # 3 minutes. The runs list is indexed a little behind the events, and
-        # a head_sha query has come back empty for a run whose check suite was
-        # already in_progress.
-        approved=0
-        for _ in $(seq 1 30); do
-          ids=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$sha" \
-            --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')
-          if [ -n "$ids" ]; then
-            for id in $ids; do
+        branch=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+
+        for attempt in 1 2 3; do
+          sha=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)
+          echo "attempt $attempt: #$PR is at $sha on $branch"
+
+          # The runs list is indexed a little behind the events, and a head_sha
+          # query has come back empty for a run whose check suite was already
+          # in_progress. Two minutes is well past that.
+          found=""
+          for _ in $(seq 1 20); do
+            found=$(runs_for "$sha")
+            [ -n "$found" ] && break
+            sleep 6
+          done
+
+          if [ -n "$found" ]; then
+            echo "$found"
+            # A parked run carries conclusion action_required. Approve every
+            # one: Branch Checkup and the iOS E2E both trigger on pull_request.
+            while read -r id conclusion; do
+              [ "$conclusion" = "action_required" ] || continue
               gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/approve"
               echo "approved run $id"
-              approved=$((approved + 1))
-            done
+            done <<< "$found"
+            exit 0
+          fi
+
+          [ "$attempt" = "3" ] && break
+
+          # No run exists for this sha, so GitHub dropped the pull_request
+          # event. It has done the same to human-opened PRs here (#251 opened
+          # with zero runs and zero check suites), and #260 lost a release sync
+          # to it while #256 and #264 came through fine.
+          #
+          # A new head sha fires synchronize and gets a fresh set. Re-running
+          # the workflow by dispatch would not: a workflow_dispatch suite has
+          # no PR attached, so the ruleset never counts it.
+          head=$(git rev-parse HEAD)
+          if [ "$head" != "$sha" ]; then
+            echo "::warning::HEAD is $head but the PR head is $sha, so there is nothing safe to re-push."
             break
           fi
-          sleep 6
+          echo "no pull_request run for $sha, amending to move the head and fire synchronize"
+          git -c user.email=gabrielstaveira@gmail.com -c user.name="Gabriel Taveira" \
+            commit --amend --no-edit --allow-empty
+          git push --force origin "HEAD:refs/heads/$branch"
+          sleep 10
         done
 
-        if [ "$approved" = "0" ]; then
-          echo "::warning::no parked pull_request run for $sha. Check whether it got a Branch Checkup run at all."
-        fi
+        echo "::error::No pull_request run ever attached to #$PR after 3 tries. The required check cannot report, so this needs an admin merge."
+        gh pr comment "$PR" --body "$(printf '%s\n' \
+          "GitHub never created a pull_request run for this PR, across three tries and two forced head moves." \
+          "" \
+          "The 👮‍♂️ context the main ruleset requires has nothing to report, so auto-merge will wait forever." \
+          "This one needs \`gh pr merge --admin\`. Run ${GITHUB_RUN_ID} has the detail.")"
+        exit 1


### PR DESCRIPTION
`.github/actions/approve-parked-ci` gains a retry. If no `pull_request` run exists for the PR's head sha after two minutes, it amends the commit and force-pushes: same content, new sha, which fires `synchronize` and gets a fresh set of runs. Three attempts, two forced head moves.

## Cause

#260 needed `gh pr merge --admin` because its head sha had zero `pull_request` runs and zero `github-actions` check suites, so the required context had nothing to report. The warning the action logged, `no parked pull_request run for 220c711`, was accurate.

GitHub drops the event here. Four PRs against main this session: #256 and #264 each got two parked runs and merged unattended, #260 and #251 got none.

#251 rules out the token and the author. I opened it myself with a user PAT, it came up just as empty as #260, and a second commit pushed to the branch started it.

## Dispatch

A `workflow_dispatch` check suite has no PR attached, so the ruleset never counts it. Re-running that way would put a green check on the right sha and leave the PR blocked.

## Fallback

When all three attempts come up empty the step emits an `::error::`, comments on the PR that it needs an admin merge, and exits non-zero. It stays `continue-on-error` because npm has already published by then, and the auto-merge step still runs, so a check that attaches late still lands the PR.

## Paths

Driven against a stub `gh` and `git`: parked runs present, runs already going, nothing until one re-push, nothing until two, and nothing at all. [Output](https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/refs/heads/gstj/pr-assets-dump/approve-parked-ci/approve-parked-ci-paths.txt).
