### PR TITLE
chore(ci): hold jest and RNTL to the Expo SDK line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
       "enabled": false
     },
     {
+      "description": "jest-expo pins the jest 29 toolchain as direct dependencies (@jest/globals, jest-snapshot, jest-environment-jsdom, babel-jest, all ^29.2.1), so jest 30 puts jest-runtime 30 next to jest-mock 29 and every suite fails to load on `this._moduleMocker.clearMocksOnScope is not a function` (#280). @testing-library/react-native 14 is built against jest 30 and wants the new test-renderer peer; under the jest 29 environment its render() returns an empty object and every screen query throws (#275). Both move with the Expo SDK, by hand.",
+      "matchPackageNames": ["jest", "@types/jest", "@testing-library/react-native"],
+      "rangeStrategy": "in-range-only"
+    },
+    {
       "description": "@expo/metro-runtime rides the Expo SDK and is held at the SDK version by a pnpm-workspace.yaml override, which the file rule above doesn't reach. The shared preset covers metro and friends but its expo-* pattern doesn't match the scoped name.",
       "matchPackageNames": ["@expo/metro-runtime"],
       "rangeStrategy": "in-range-only"


### PR DESCRIPTION
Renovate opened jest 30 (#280) and @testing-library/react-native 14 (#275) tonight. Both are dead on arrival while we're on Expo SDK 55, so this holds them to in-range-only rather than letting Renovate re-raise them every week.

jest-expo 57 lists the jest 29 toolchain as direct dependencies: `@jest/globals`, `jest-snapshot`, `jest-environment-jsdom` and `babel-jest`, all `^29.2.1`. Install jest 30 and jest-runtime 30 ends up calling `this._moduleMocker.clearMocksOnScope` on jest-mock 29, so all four suites fail to load. It also drags in `unrs-resolver`, whose build script pnpm 11 refuses to run without an `allowBuilds` entry, so the install dies before the tests get a chance.

RNTL 14 is built against jest 30 (`jest-matcher-utils` and `pretty-format` at `^30.4.1`) and swaps react-test-renderer for the new `test-renderer` peer. Under the jest 29 environment its `render()` returns an empty object for a bare `<Text>` and every `screen` query throws "`render` function has not been called". Adding `test-renderer@^1.2.0` doesn't change it.

Same treatment react-native and the example app's runtime already get in this file, for the same reason: the Expo SDK decides, and these move by hand when it does.
