### PR TITLE
fix(ci): put the e2e runner back on macos-15

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -74,7 +74,11 @@ jobs:
     name: 🧪 Maestro smoke tests (iOS sim)
     needs: approval-gate
     if: needs.approval-gate.outputs.approved == 'true'
-    runs-on: macos-26
+    # Not macos-26: that image ships iOS 26.2/26.4/26.5 simulator runtimes but
+    # not 26.0, and xcodebuild fails the storyboard compile with "iOS 26.0
+    # Platform Not Installed". macos-15 has 26.0 alongside Xcode 26. #284 moved
+    # it and broke the build; this puts it back.
+    runs-on: macos-15
     timeout-minutes: 60
     env:
       EXAMPLE_DIR: examples/kitchen-sink

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
       "rangeStrategy": "in-range-only"
     },
     {
+      "description": "The e2e runner image is not a free bump. macos-26 dropped the iOS 26.0 simulator runtime and the iPhone SE (3rd generation) device, and xcodebuild fails the storyboard compile with \"iOS 26.0 Platform Not Installed\" (#284, reverted). Moves by hand once the app's deployment target moves with it.",
+      "matchDepNames": ["macos"],
+      "enabled": false
+    },
+    {
       "description": "@expo/metro-runtime rides the Expo SDK and is held at the SDK version by a pnpm-workspace.yaml override, which the file rule above doesn't reach. The shared preset covers metro and friends but its expo-* pattern doesn't match the scoped name.",
       "matchPackageNames": ["@expo/metro-runtime"],
       "rangeStrategy": "in-range-only"


### PR DESCRIPTION
I merged #284 tonight and it broke the iOS build. Putting it back.

macos-26 ships iOS 26.2, 26.4 and 26.5 simulator runtimes but not 26.0, so xcodebuild dies compiling `SplashScreen.storyboard` with "iOS 26.0 Platform Not Installed" and exits 65. It also dropped the iPhone SE (3rd generation) that the boot step picks up. macos-15 has both, plus the Xcode 26 the "Select Xcode 26" step already goes looking for, so nothing else in the job changes.

Also holding macos in renovate.json. The bump is real work once the app's deployment target catches up, and it isn't something that can ride an automerge.

Failing run for the record: https://github.com/GSTJ/react-native-magic-modal/actions/runs/30316506779
