### PR TITLE
fix(ci): stop bot-quoted breaking notes from driving the release bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,24 +153,41 @@ jobs:
           #     (`feat!:`, `fix(deps)!:`), which conventional-commits treats as
           #     a major on its own, with or without a footer,
           #   - its body contains a line starting with `BREAKING CHANGE:`
-          #     or `BREAKING-CHANGE:` (the conventional-commits footer).
+          #     or `BREAKING-CHANGE:` (the conventional-commits footer) AND a
+          #     human wrote it.
           # We can't use `git log --grep` here because that searches the
           # entire commit message; a PR description that mentions
           # "BREAKING CHANGE" in prose would falsely match. Iterate
           # commits with a unit separator and check each part explicitly.
+          #
+          # The author check is the same guard `packages/modal/.release-it.js`
+          # applies to the bump, kept here so the two agree. Squash-merging a
+          # PR puts the PR description in the commit body, and a Renovate
+          # description quotes the upstream project's changelog verbatim — so a
+          # dependency chore can carry someone else's `BREAKING CHANGE:` line
+          # and, without this, qualify for a release the repo never wanted.
+          # `%an` on a squash merge is the PR author, off the commit object, so
+          # nothing in a PR description can forge it. The `!` marker above is
+          # deliberate and still counts for anyone, which is the escape hatch
+          # for a human pushing a real breaking change onto a bot branch. An
+          # unrecognised author is treated as a human on purpose.
           UNIT=$'\x1f'
           REC=$'\x1e'
-          COMMITS=$(git log "$BOUNDARY..HEAD" --pretty=format:"%H${UNIT}%s${UNIT}%b${REC}")
+          COMMITS=$(git log "$BOUNDARY..HEAD" --pretty=format:"%H${UNIT}%an${UNIT}%s${UNIT}%b${REC}")
           QUALIFY=""
           while IFS= read -r -d "$REC" entry; do
             [ -z "$entry" ] && continue
             sha=$(printf '%s' "$entry" | awk -F"$UNIT" '{print $1}')
-            subject=$(printf '%s' "$entry" | awk -F"$UNIT" '{print $2}')
-            body=$(printf '%s' "$entry" | awk -F"$UNIT" '{for(i=3;i<=NF;i++) printf "%s%s", $i, (i<NF?FS:"")}')
+            author=$(printf '%s' "$entry" | awk -F"$UNIT" '{print $2}')
+            subject=$(printf '%s' "$entry" | awk -F"$UNIT" '{print $3}')
+            body=$(printf '%s' "$entry" | awk -F"$UNIT" '{for(i=4;i<=NF;i++) printf "%s%s", $i, (i<NF?FS:"")}')
             if printf '%s' "$subject" | grep -qE '\(modal\)|^[a-zA-Z]+(\([^)]*\))?!:'; then
               QUALIFY="${QUALIFY}${subject}"$'\n'
               continue
             fi
+            case "$author" in
+              'renovate[bot]'|'dependabot[bot]'|'github-actions[bot]') continue ;;
+            esac
             if printf '%s' "$body" | grep -qE '^BREAKING[- ]CHANGE:'; then
               QUALIFY="${QUALIFY}${subject}"$'\n'
             fi

--- a/packages/modal/.release-it.js
+++ b/packages/modal/.release-it.js
@@ -1,3 +1,136 @@
+import createPreset from "conventional-changelog-conventionalcommits";
+
+// One list, used twice: once as the preset the plugin loads, once to build the
+// preset we borrow `whatBump` from below. Declaring it here keeps the two from
+// drifting apart.
+const types = [
+  {
+    type: "fix",
+    section: ":hammer: Bug Fixes :hammer:",
+    hidden: false,
+  },
+  {
+    type: "feat",
+    section: ":stars: New Features :stars:",
+    hidden: false,
+  },
+  {
+    type: "refactor",
+    section: ":dash: Code Improvements :dash:",
+    hidden: false,
+  },
+  {
+    type: "perf",
+    section: ":dash: Code Improvements :dash:",
+    hidden: false,
+  },
+  {
+    type: "test",
+    section: ":link: Testing Updated :link:",
+    hidden: false,
+  },
+  {
+    type: "breaking",
+    section: ":boom: BREAKING CHANGE :boom:",
+    hidden: false,
+  },
+  {
+    type: "revert",
+    section: ":x: Removed :x:",
+    hidden: false,
+  },
+  {
+    type: "ci",
+    section: ":curly_loop: Continuous Integrations :curly_loop:",
+    hidden: false,
+  },
+  {
+    type: "chore",
+    section: ":curly_loop: What a drag! :curly_loop:",
+    hidden: true,
+  },
+];
+
+// Squash-merging a PR puts the PR description in the commit body, and Renovate
+// PR descriptions quote the upstream project's changelog verbatim. Several
+// merged commits therefore carry other projects' release notes, breaking-change
+// sections included: `chore(deps): update dependency uuid to v14` (#295) has
+// three `##### ⚠ BREAKING CHANGES` headings in its body.
+//
+// Those headings happen to be inert. conventional-commits-parser only reads a
+// note from `^[\s|*]*(BREAKING CHANGE|BREAKING-CHANGE)[:\s]+`, and the heading
+// is both hash-prefixed and plural, so it misses on two counts. Measured, not
+// assumed. What is *not* inert is an upstream project that hand-writes
+// `BREAKING CHANGE: ...` at the start of a line in its release notes. Renovate
+// would quote that verbatim too, the parser would take it, and the next release
+// would compute a major off a dependency chore — publishing a bogus 10.0.0 to
+// npm and writing someone else's breaking changes into this changelog.
+//
+// This repo has already shipped two wrong majors from bump miscomputation
+// (8.0.0 and 9.0.0, see the tagOpts comment below), and the pipeline publishes
+// to npm without a human in the loop, so a wrong major is not something that
+// can be taken back. Hence the guard.
+//
+// The discriminator is authorship, not text. `%an` on a squash merge is the PR
+// author — `renovate[bot]` for a bot PR — and it comes off the commit object,
+// so nothing written in a PR description can forge it. Matching on the shape of
+// the prose instead would be a guessing game against whatever upstream writes
+// next.
+const BOT_AUTHORS = new Set([
+  "renovate[bot]",
+  "dependabot[bot]",
+  "github-actions[bot]",
+]);
+
+// `feat!:`, `fix(deps)!:`. A subject-line marker is deliberate in a way quoted
+// prose is not, so it keeps counting no matter who authored the commit. It is
+// also the escape hatch for the one case where a bot-authored commit really is
+// breaking: a human pushing onto a Renovate branch writes the `!` and the bump
+// still goes major.
+const BREAKING_MARKER = /^[a-zA-Z]+(\([^)]*\))?!:/;
+
+/**
+ * A commit as conventional-commits-parser hands it to `whatBump`. `authorName`
+ * is there because of the `commitsOpts.format` below; without it the field is
+ * simply absent, which the guard reads as "not a bot".
+ *
+ * @typedef {{
+ *   authorName?: string;
+ *   header?: string;
+ *   notes?: unknown[];
+ * }} ParsedCommit
+ */
+
+/**
+ * Drop breaking notes that a bot's commit body picked up from somewhere else.
+ * Humans are never touched, so a hand-written `BREAKING CHANGE:` footer behaves
+ * exactly as it did before this guard existed. An author we don't recognise is
+ * treated as a human: the failure worth having here is over-counting a breaking
+ * change, never silently swallowing one.
+ *
+ * @param {ParsedCommit} commit
+ * @returns {ParsedCommit}
+ */
+const dropQuotedNotes = (commit) => {
+  if (!BOT_AUTHORS.has(commit.authorName ?? "")) return commit;
+  if (BREAKING_MARKER.test(commit.header ?? "")) return commit;
+  if (!commit.notes?.length) return commit;
+  return { ...commit, notes: [] };
+};
+
+// `whatBump` borrowed rather than reimplemented. It reads `types` to decide
+// which commits move the version at all, and rewriting that by hand here is how
+// a config quietly stops doing what its comment claims — which is the whole
+// story of the 8.0.0 and 9.0.0 releases.
+//
+// The double cast is upstream's typing gap: the preset publishes
+// `createPreset(config?): {}`, so its own return value doesn't describe the
+// `whatBump` it demonstrably returns.
+const preset =
+  /** @type {{ whatBump: (commits: ParsedCommit[]) => unknown }} */ (
+    /** @type {unknown} */ (await createPreset({ types }))
+  );
+
 export default {
   plugins: {
     "@release-it/conventional-changelog": {
@@ -19,55 +152,20 @@ export default {
       // only uses it for the changelog, never for the bump. `tagOpts` is what
       // reaches the bumper.
       tagOpts: { prefix: "magic-modal-" },
+      // The bumper's default format is `%B%n-hash-%n%H`. `-fieldName-` lines
+      // are how conventional-commits-parser exposes extra git fields on the
+      // parsed commit (`fieldPattern`), so appending one gets us `authorName`
+      // for the guard above. `-hash-` is kept because dropping it would take
+      // `commit.hash` with it.
+      //
+      // Bump path only. The changelog generator takes `gitRawCommitsOpts`, not
+      // this, so the rendered notes are unaffected.
+      commitsOpts: { format: "%B%n-hash-%n%H%n-authorName-%n%an" },
+      whatBump: (/** @type {ParsedCommit[]} */ commits) =>
+        preset.whatBump(commits.map(dropQuotedNotes)),
       preset: {
         name: "conventionalcommits",
-        types: [
-          {
-            type: "fix",
-            section: ":hammer: Bug Fixes :hammer:",
-            hidden: false,
-          },
-          {
-            type: "feat",
-            section: ":stars: New Features :stars:",
-            hidden: false,
-          },
-          {
-            type: "refactor",
-            section: ":dash: Code Improvements :dash:",
-            hidden: false,
-          },
-          {
-            type: "perf",
-            section: ":dash: Code Improvements :dash:",
-            hidden: false,
-          },
-          {
-            type: "test",
-            section: ":link: Testing Updated :link:",
-            hidden: false,
-          },
-          {
-            type: "breaking",
-            section: ":boom: BREAKING CHANGE :boom:",
-            hidden: false,
-          },
-          {
-            type: "revert",
-            section: ":x: Removed :x:",
-            hidden: false,
-          },
-          {
-            type: "ci",
-            section: ":curly_loop: Continuous Integrations :curly_loop:",
-            hidden: false,
-          },
-          {
-            type: "chore",
-            section: ":curly_loop: What a drag! :curly_loop:",
-            hidden: true,
-          },
-        ],
+        types,
       },
       // There used to be a `commitFilter` here meant to keep the changelog to
       // (modal)-scoped and breaking commits. @release-it/conventional-changelog

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -60,6 +60,7 @@
     "@types/jest": "^29.5.14",
     "@types/react": "~19.2.14",
     "bunchee": "^6.0.3",
+    "conventional-changelog-conventionalcommits": "^10.2.1",
     "cz-conventional-changelog": "^3.3.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       bunchee:
         specifier: ^6.0.3
         version: 6.12.1(typescript@5.9.3)
+      conventional-changelog-conventionalcommits:
+        specifier: ^10.2.1
+        version: 10.2.1
       cz-conventional-changelog:
         specifier: ^3.3.0
         version: 3.3.0(@types/node@26.1.1)(typescript@5.9.3)


### PR DESCRIPTION
A dependency chore can compute a major and publish it to npm. This PR makes the bump ignore breaking notes that a bot's commit body picked up from another project's changelog.

Renovate PR descriptions quote the upstream changelog, and squash-merging drops that description into the commit body. `chore(deps): update dependency uuid to v14` (#295) carries three `##### ⚠ BREAKING CHANGES` headings from uuid.

Those headings don't register. conventional-commits-parser reads a note from `^[\s|*]*(BREAKING CHANGE|BREAKING-CHANGE)[:\s]+`, and the heading is hash-prefixed and plural. The recommended bump over `magic-modal-9.0.0..HEAD` is patch, with zero notes across all 27 commits.

An upstream project that hand-writes a breaking footer at the start of a line does register. Renovate quotes that verbatim too, the parser takes it, and the release computes a major. That publishes a bogus 10.0.0 with another project's breaking changes in our changelog. 8.0.0 and 9.0.0 were both wrong majors out of bump miscomputation (#261).

## Guard

The discriminator is authorship. `%an` on a squash merge is the PR author, and it comes off the commit object, so a PR description can't forge it. Matching on the shape of the prose means guessing what upstream writes next.

- `packages/modal/.release-it.js` asks the bumper for `authorName` (`commitsOpts.format`, through the parser's `-fieldName-` mechanism) and drops body-derived notes from bot-authored commits before the preset's `whatBump` sees them.
- `.github/workflows/release.yml` applies the same rule in the "Determine next version" probe.

Human commits go through unchanged. A subject-line `!` still counts for anyone, which covers a human pushing a real breaking change onto a Renovate branch. An author the list doesn't recognise is treated as a human.

`whatBump` comes from the preset rather than being reimplemented, since it reads `types` to decide which commits move the version at all. A hand-rolled copy would drift from the preset without anything failing. That needs `conventional-changelog-conventionalcommits` declared; it was already in the tree at the same 10.2.1 the plugin resolves, and the lockfile still has one copy.

## Proof

![bump guard before and after](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-modal-301-bump-guard/magic-modal/301/bump-guard-proof.png)

Same 27-commit range, same bumper, one synthetic 28th commit that differs only in authorship and body shape. B and F are the failure being closed: major before, patch after. C, D, E and G have to stay major, and do.

The bumper is conventional-recommended-bump 12.1.0 / conventionalcommits 10.2.1 / conventional-commits-parser 7.1.1, driven through a replica of `@release-it/conventional-changelog` 12.0.0's `getRecommendedVersion()`. Raw output sits next to the image on the assets branch.

The last block runs the real binary rather than a replica. `release-it --release-version --ci` in `packages/modal`, over case B, prints 10.0.0 on main's config and 9.0.1 on this one. The old `commitFilter` sat in this config for two releases doing nothing, because the plugin never read that key. Running the tool itself rules that out for `whatBump`.

## Scope

Renovate's `prBodyTemplate` still includes `{{{changelogs}}}`, so upstream release notes keep landing in commit bodies. Dropping them removes the main thing worth reading on a dependency major.

The changelog writer isn't filtered. If a release runs for some other reason, a bot's quoted note could still render into CHANGELOG.md. That needs the preset's writer transform wrapped.

No release comes out of this PR. `fix(ci)` carries no `(modal)` scope and no `!`, so the probe skips it, and the real range is still patch with `skip=true`.

## CI

`@magic/kitchen-sink#doctor` is red here and on unmodified main. expo-doctor now wants react-native 0.83.10 where the repo pins 0.83.6, and the `doctor` task has `"cache": false`, so it re-checks against Expo's API on every run. I re-ran the last green main checkup (run 30327485080, commit 00357ef, nothing of mine in it) and it fails the same check. Nothing on this branch touches Expo, react-native, or `examples/`; the lockfile diff is the three lines that add the preset. Lint, format and typecheck pass.
