### PR TITLE
fix(changelog): render the types that reach the tarball

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -30,9 +30,15 @@ jobs:
       # generated API tables cannot merge and fail only during deployment.
       build-command: pnpm run build
       test-command: pnpm run test
-      # This repo's own gate: expo-doctor catches the duplicate react-native and
-      # the SDK drift the example app is prone to.
-      extra-command: pnpm run doctor
+      # This repo's own gates. expo-doctor catches the duplicate react-native
+      # and the SDK drift the example app is prone to. changelog:check renders
+      # a synthetic history of every commit type through the real changelog
+      # preset and fails if a breaking change goes missing — including one
+      # hanging off a hidden type, which is how a `ci!:` would vanish.
+      #
+      # One `extra-command`, so they're chained. `&&` short-circuits, which is
+      # what we want: either failing fails the job.
+      extra-command: pnpm run doctor && pnpm run changelog:check
 
   # main's ruleset requires a check literally named "👮‍♂️ Typecheck, Healthcheck,
   # Lint and Format". A called workflow always reports as

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typecheck": "turbo run typecheck",
     "start": "turbo run start",
     "test": "turbo run test",
+    "changelog:check": "turbo run changelog:check --filter=react-native-magic-modal",
     "build": "turbo run build",
     "release": "turbo run release --filter=react-native-magic-modal",
     "docs": "pnpm --filter @magic-modal/docs build",

--- a/packages/modal/.release-it.js
+++ b/packages/modal/.release-it.js
@@ -1,55 +1,11 @@
 import createPreset from "conventional-changelog-conventionalcommits";
 
-// One list, used twice: once as the preset the plugin loads, once to build the
-// preset we borrow `whatBump` from below. Declaring it here keeps the two from
-// drifting apart.
-const types = [
-  {
-    type: "fix",
-    section: ":hammer: Bug Fixes :hammer:",
-    hidden: false,
-  },
-  {
-    type: "feat",
-    section: ":stars: New Features :stars:",
-    hidden: false,
-  },
-  {
-    type: "refactor",
-    section: ":dash: Code Improvements :dash:",
-    hidden: false,
-  },
-  {
-    type: "perf",
-    section: ":dash: Code Improvements :dash:",
-    hidden: false,
-  },
-  {
-    type: "test",
-    section: ":link: Testing Updated :link:",
-    hidden: false,
-  },
-  {
-    type: "breaking",
-    section: ":boom: BREAKING CHANGE :boom:",
-    hidden: false,
-  },
-  {
-    type: "revert",
-    section: ":x: Removed :x:",
-    hidden: false,
-  },
-  {
-    type: "ci",
-    section: ":curly_loop: Continuous Integrations :curly_loop:",
-    hidden: false,
-  },
-  {
-    type: "chore",
-    section: ":curly_loop: What a drag! :curly_loop:",
-    hidden: true,
-  },
-];
+// One list, used three times: as the preset the plugin loads, to build the
+// preset we borrow `whatBump` from below, and by tools/changelog-check.mjs.
+// It lives in tools/changelog-preset.mjs so the check can't pass against a
+// policy the release doesn't use — that file also explains what each `effect`
+// buys.
+import { TYPES as types } from "./tools/changelog-preset.mjs";
 
 // Squash-merging a PR puts the PR description in the commit body, and Renovate
 // PR descriptions quote the upstream project's changelog verbatim. Several

--- a/packages/modal/oxlint.config.mts
+++ b/packages/modal/oxlint.config.mts
@@ -13,6 +13,12 @@ import reactNative from "magic-oxlint-config/react-native";
 export default extendConfig(reactNative, {
   overrides: [
     {
+      // tools/ holds the changelog preset and its control script. Printing to
+      // the terminal is what the control is for — the CI job reads its output.
+      files: ["tools/**"],
+      rules: { "no-console": "off" },
+    },
+    {
       // release-it only looks for this exact filename, so it misses the
       // preset's `*.config.{js,…}` glob even though it is a config file.
       files: [".release-it.js"],

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -51,6 +51,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "copy:readme": "shx cp ../../README.md ./README.md",
     "test": "jest",
+    "changelog:check": "node tools/changelog-check.mjs",
     "release": "release-it --ci"
   },
   "devDependencies": {
@@ -59,7 +60,9 @@
     "@types/jest": "^29.5.14",
     "@types/react": "~19.2.14",
     "bunchee": "^6.0.3",
+    "conventional-changelog": "^8.1.0",
     "conventional-changelog-conventionalcommits": "^10.2.1",
+    "conventional-recommended-bump": "^12.1.0",
     "cz-conventional-changelog": "^3.3.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/packages/modal/tools/changelog-check.mjs
+++ b/packages/modal/tools/changelog-check.mjs
@@ -1,0 +1,332 @@
+// Control for tools/changelog-preset.mjs.
+//
+// The preset decides which commit types reach the changelog and which of them
+// can move the version, so the risk it carries is silent omission: mark a type
+// hidden and its commits vanish with no error anywhere. A breaking change
+// vanishing that way is the one failure this package cannot ship.
+//
+// POLICY below is written out longhand on purpose. Deriving it from the
+// preset's own type list would make every assertion a tautology — hide a
+// section and the check would just change its mind about what it expected. So
+// the policy is stated here, the preset is asserted to match it, and the
+// rendered output is asserted to match it too. Changing what reaches the
+// changelog means changing both files, deliberately.
+//
+// Three things get checked:
+//
+//   1. the type list agrees with the policy
+//   2. a synthetic history of every type renders the way the policy says,
+//      including the `ci!:` case — `ci` is hidden and its breaking note still
+//      has to surface
+//   3. the recommended bump respects `effect`, so a release of nothing but
+//      `build:` and `chore:` commits cannot come out a minor
+//
+// Then it renders the same history through a sabotaged type list and fails if
+// *that* passes. An assertion that cannot fail is worth nothing.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Bumper } from "conventional-recommended-bump";
+
+import preset, { TYPES } from "./changelog-preset.mjs";
+
+const here = import.meta.dirname;
+const presetPath = join(here, "changelog-preset.mjs");
+// Resolved rather than assumed to sit at ../node_modules/.bin: pnpm hoists, and
+// in a workspace the binary can land in the root store instead of the package.
+// The package exports no `./package.json`, so resolve its entry point and walk
+// across to the CLI beside it.
+const cliEntry = fileURLToPath(import.meta.resolve("conventional-changelog"));
+const cliPath = join(dirname(cliEntry), "cli", "index.js");
+
+/**
+ * What each type is for. `bump` can raise the version, `changelog` renders
+ * without raising it, `hidden` does neither.
+ *
+ * @type {Record<string, "bump" | "changelog" | "hidden">}
+ */
+const POLICY = {
+  feat: "bump",
+  feature: "bump",
+  fix: "bump",
+  perf: "bump",
+  revert: "bump",
+  build: "changelog",
+  refactor: "changelog",
+  chore: "changelog",
+  docs: "changelog",
+  ci: "hidden",
+  style: "hidden",
+  test: "hidden",
+};
+
+// One commit per type, plus three breaking ones spread across a bump type, a
+// changelog type and a hidden type.
+const COMMITS = [
+  "feat: add a thing",
+  "fix: correct a thing",
+  "build: shrink the tarball",
+  "refactor: rewrite the internals",
+  "chore(deps): bump something",
+  "docs: update the readme",
+  "ci: tweak the workflow",
+  "style: reformat",
+  "test: add cases",
+  "perf!: drop the slow path\n\nBREAKING CHANGE: the slow path is gone",
+  "chore: retire the legacy loader\n\nBREAKING CHANGE: the legacy loader is gone",
+  "ci!: require node 24\n\nBREAKING CHANGE: node 22 is no longer supported",
+];
+
+// Subject fragment -> the type it was committed under. Matching on subjects
+// rather than section headings keeps the check working in a repo that renames
+// its sections.
+const SUBJECTS = {
+  feat: "add a thing",
+  fix: "correct a thing",
+  build: "shrink the tarball",
+  refactor: "rewrite the internals",
+  chore: "bump something",
+  docs: "update the readme",
+  ci: "tweak the workflow",
+  style: "reformat",
+  test: "add cases",
+};
+
+const NOTES = {
+  "a bump type (perf!)": "the slow path is gone",
+  "a changelog type (chore!)": "the legacy loader is gone",
+  "a HIDDEN type (ci!)": "node 22 is no longer supported",
+};
+
+/**
+ * Builds a throwaway repo out of `commits` and hands it to `run`. Async on
+ * purpose: `bumpFor` below is, and a synchronous `finally` would delete the
+ * repo out from under it.
+ *
+ * `tag` says where v1.0.0 goes, and the two callers need different answers.
+ * The renderer wants it last, so `--release-count 0` has a released section to
+ * render — a chunk whose version matches the last tag comes out empty. The
+ * bumper wants it first, so the commits are the range being measured.
+ *
+ * @template T
+ * @param {string[]} commits
+ * @param {"before" | "after"} tag
+ * @param {(repo: string) => T | Promise<T>} run
+ * @returns {Promise<T>}
+ */
+const inThrowawayRepo = async (commits, tag, run) => {
+  const repo = mkdtempSync(join(tmpdir(), "magic-modal-changelog-"));
+  /** @param {string[]} args */
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: repo, encoding: "utf8", stdio: "pipe" });
+
+  try {
+    git("init", "--quiet", "--initial-branch", "main");
+    git("config", "user.email", "check@example.com");
+    git("config", "user.name", "changelog check");
+    writeFileSync(
+      join(repo, "package.json"),
+      JSON.stringify({ name: "changelog-check", version: "1.0.0" }),
+    );
+    git("add", ".");
+    git("commit", "--quiet", "-m", "chore: initial");
+    if (tag === "before") git("tag", "-a", "v1.0.0", "-m", "v1.0.0");
+
+    for (const message of commits) {
+      git(
+        "commit",
+        "--quiet",
+        "--allow-empty",
+        "--cleanup=verbatim",
+        "-m",
+        message,
+      );
+    }
+
+    if (tag === "after") git("tag", "-a", "v1.0.0", "-m", "v1.0.0");
+
+    return await run(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+};
+
+/**
+ * Renders COMMITS through a preset module and returns the changelog text.
+ *
+ * @param {string} configPath
+ * @returns {Promise<string>}
+ */
+const render = (configPath) =>
+  inThrowawayRepo(COMMITS, "after", (repo) =>
+    execFileSync(
+      process.execPath,
+      [cliPath, "--config", configPath, "--release-count", "0", "--stdout"],
+      { cwd: repo, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+    ),
+  );
+
+/**
+ * The release type conventional-recommended-bump lands on for `commits`, read
+ * through the real preset. `null` means "nothing here warrants a release".
+ *
+ * @param {string[]} commits
+ * @returns {Promise<string | null>}
+ */
+const bumpFor = (commits) =>
+  inThrowawayRepo(commits, "before", async (repo) => {
+    const bumper = new Bumper(repo);
+    bumper.loadPreset({ name: "conventionalcommits", types: TYPES });
+    // Same double cast .release-it.js needs: the preset publishes
+    // `createPreset(config?): {}`, so its own return type doesn't describe the
+    // `whatBump` it demonstrably returns. `bump()` is typed as a union whose
+    // empty arm has no `releaseType`, which is the `null` case here.
+    const { whatBump } =
+      /** @type {{ whatBump: Parameters<Bumper["bump"]>[0] }} */ (
+        /** @type {unknown} */ (await preset)
+      );
+    const recommendation = /** @type {{ releaseType?: string }} */ (
+      await bumper.bump(whatBump)
+    );
+    return recommendation.releaseType ?? null;
+  });
+
+/** @type {string[]} */
+const failures = [];
+/**
+ * @param {string} label
+ * @param {boolean} condition
+ */
+const expect = (label, condition) => {
+  if (!condition) failures.push(label);
+};
+
+// 1. The type list says what the policy says.
+for (const [type, effect] of Object.entries(POLICY)) {
+  const entry = TYPES.find((candidate) => candidate.type === type);
+  expect(`${type} is in the type list`, entry !== undefined);
+  expect(`${type} is "${effect}"`, entry?.effect === effect);
+}
+for (const entry of TYPES) {
+  expect(`${entry.type} is covered by the policy`, entry.type in POLICY);
+}
+
+/**
+ * 2. The rendered output says what the policy says.
+ *
+ * @param {string} output
+ * @returns {string[]}
+ */
+const assessRendering = (output) => {
+  /** @type {string[]} */
+  const found = [];
+  /**
+   * @param {string} label
+   * @param {boolean} condition
+   */
+  const check = (label, condition) => {
+    if (!condition) found.push(label);
+  };
+
+  // Breaking changes render whatever type they hang off, hidden ones included.
+  // The preset prefixes the heading with a warning sign, so match on the words.
+  check("BREAKING CHANGES heading", /^### .*BREAKING CHANGES$/m.test(output));
+  for (const [label, text] of Object.entries(NOTES)) {
+    check(`breaking note on ${label}`, output.includes(text));
+  }
+
+  for (const [type, subject] of Object.entries(SUBJECTS)) {
+    const shouldRender = POLICY[type] !== "hidden";
+    check(
+      shouldRender ? `${type} renders` : `${type} stays hidden`,
+      output.includes(subject) === shouldRender,
+    );
+  }
+
+  return found;
+};
+
+failures.push(...assessRendering(await render(presetPath)));
+
+// 3. `effect` decides the bump, not just the rendering. The middle case is the
+// one that matters: those four types all render, and none of them may push a
+// release past a patch.
+const bumps = {
+  breaking: await bumpFor(["feat!: drop the old API"]),
+  feature: await bumpFor(["feat: add a thing"]),
+  fix: await bumpFor(["fix: correct a thing"]),
+  changelogOnly: await bumpFor([
+    "build: shrink the tarball",
+    "refactor: rewrite the internals",
+    "chore(deps): bump something",
+    "docs: update the readme",
+  ]),
+  hiddenOnly: await bumpFor(["ci: tweak the workflow", "style: reformat"]),
+};
+
+expect("a breaking feat is a major", bumps.breaking === "major");
+expect("a feat is a minor", bumps.feature === "minor");
+expect("a fix is a patch", bumps.fix === "patch");
+expect(
+  `build/refactor/chore/docs alone do not bump (got ${bumps.changelogOnly})`,
+  bumps.changelogOnly === null,
+);
+expect(
+  `ci/style alone do not bump (got ${bumps.hiddenOnly})`,
+  bumps.hiddenOnly === null,
+);
+
+if (failures.length > 0) {
+  console.error("changelog preset check FAILED:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+// Negative control. Same commits, same assertions, a type list with every
+// visible type forced to `hidden`. POLICY doesn't move, so hiding a section has
+// to show up as a failure.
+const sabotaged = TYPES.map((entry) =>
+  entry.effect === "hidden" ? entry : { ...entry, effect: "hidden" },
+);
+// Written next to the real preset rather than in the temp dir so the bare
+// `conventional-changelog-conventionalcommits` specifier still resolves.
+const sabotagedPath = join(
+  here,
+  `.changelog-preset-sabotaged.${process.pid}.mjs`,
+);
+writeFileSync(
+  sabotagedPath,
+  'import createPreset from "conventional-changelog-conventionalcommits";\n' +
+    `export default createPreset({ types: ${JSON.stringify(sabotaged)} });\n`,
+);
+
+let sabotagedFailures;
+try {
+  sabotagedFailures = assessRendering(await render(sabotagedPath));
+} finally {
+  rmSync(sabotagedPath, { force: true });
+}
+
+if (sabotagedFailures.length === 0) {
+  console.error(
+    "negative control FAILED: hiding every visible type changed nothing, so the assertions above are not testing anything.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `changelog preset check passed (${COMMITS.length} synthetic commits, 3 breaking; bumps: feat!=${bumps.breaking}, feat=${bumps.feature}, fix=${bumps.fix}, changelog-only=${bumps.changelogOnly}, hidden-only=${bumps.hiddenOnly})`,
+);
+console.log(
+  `negative control passed (hiding the visible types breaks ${sabotagedFailures.length} assertions: ${sabotagedFailures.join(", ")})`,
+);
+
+// `--print` is for looking at the control by hand, which is the only way to
+// judge the section names and ordering. The assertions above cannot.
+if (process.argv.includes("--print")) {
+  console.log("\n--- rendered through the real preset ---\n");
+  console.log(await render(presetPath));
+}

--- a/packages/modal/tools/changelog-preset.mjs
+++ b/packages/modal/tools/changelog-preset.mjs
@@ -1,0 +1,85 @@
+// The commit types that reach the changelog, and which of them can move the
+// version. `.release-it.js` and `tools/changelog-check.mjs` both import this
+// list, so the check can't pass against a policy the release doesn't use.
+//
+// Section names are this repo's own. They are what the shipped release bodies
+// use, and renaming them would make CHANGELOG.md read as two projects.
+//
+// What changed, and why:
+//
+//   `effect` replaces `hidden`. conventional-changelog-conventionalcommits 10
+//   reads `effect` and nothing else — `hidden: true` is dead config there. So
+//   `chore` was never actually hidden. The 9.0.1 release body lists 20
+//   dependency and CI chores under ":curly_loop: What a drag! :curly_loop:",
+//   off an entry this file marked `hidden: true`. The list now says what the
+//   generator does.
+//
+//   `build` and `docs` were absent from the list entirely, and a type the list
+//   doesn't mention is discarded, so 9.0.1 shipped without the two `docs(ci)`
+//   commits in its range (#298 and #300). Both types change what ships:
+//   `dist/` is the whole tarball and bunchee's config decides its contents,
+//   and README.md is packed alongside it.
+//
+//   `ci`, `style` and `test` move to hidden. `files` is `["dist"]`, so
+//   `.github/`, source formatting and `src/**` tests cannot reach a consumer.
+//   `ci` in particular was rendering its own section while the dependency
+//   chores that actually move `dist/` were meant to be hidden, which is
+//   backwards.
+//
+//   The `breaking` entry is gone. `breaking:` is not a conventional-commits
+//   type, no commit in this repo has ever used it, and the section it pointed
+//   at is not the one breaking changes render under — the writer hardcodes
+//   that heading and reaches it from a note, not from a type.
+//
+// The bump/changelog split is the point of `effect`. Only `feat`, `fix`,
+// `perf` and `revert` can raise a version. `build`, `refactor`, `chore` and
+// `docs` render without bumping, so a month of dependency chores is still a
+// patch. This repo has published two wrong majors off a miscomputed bump
+// (8.0.0 and 9.0.0, see the tagOpts comment in .release-it.js), and the
+// pipeline publishes to npm with no human in the loop, so widening what
+// renders must not widen what bumps.
+//
+// Breaking changes are not configurable here and don't need to be. The
+// preset's writer sets `discard = false` the moment a commit carries a note,
+// so a `BREAKING CHANGE:` footer or a `!` renders its own section whatever
+// type it hangs off, hidden ones included. tools/changelog-check.mjs is the
+// control for that.
+import createPreset from "conventional-changelog-conventionalcommits";
+
+/** @type {import("conventional-changelog-conventionalcommits").CommitType[]} */
+export const TYPES = [
+  { type: "fix", section: ":hammer: Bug Fixes :hammer:", effect: "bump" },
+  { type: "feat", section: ":stars: New Features :stars:", effect: "bump" },
+  { type: "feature", section: ":stars: New Features :stars:", effect: "bump" },
+  {
+    type: "refactor",
+    section: ":dash: Code Improvements :dash:",
+    effect: "changelog",
+  },
+  { type: "perf", section: ":dash: Code Improvements :dash:", effect: "bump" },
+  { type: "revert", section: ":x: Removed :x:", effect: "bump" },
+  {
+    type: "chore",
+    section: ":curly_loop: What a drag! :curly_loop:",
+    effect: "changelog",
+  },
+  {
+    type: "build",
+    section: ":package: Build System :package:",
+    effect: "changelog",
+  },
+  {
+    type: "docs",
+    section: ":books: Documentation :books:",
+    effect: "changelog",
+  },
+  {
+    type: "ci",
+    section: ":curly_loop: Continuous Integrations :curly_loop:",
+    effect: "hidden",
+  },
+  { type: "style", section: ":lipstick: Styles :lipstick:", effect: "hidden" },
+  { type: "test", section: ":link: Testing Updated :link:", effect: "hidden" },
+];
+
+export default createPreset({ types: TYPES });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,9 +205,15 @@ importers:
       bunchee:
         specifier: ^6.0.3
         version: 6.12.1(typescript@5.9.3)
+      conventional-changelog:
+        specifier: ^8.1.0
+        version: 8.1.0(conventional-commits-filter@6.0.1)
       conventional-changelog-conventionalcommits:
         specifier: ^10.2.1
         version: 10.2.1
+      conventional-recommended-bump:
+        specifier: ^12.1.0
+        version: 12.1.0
       cz-conventional-changelog:
         specifier: ^3.3.0
         version: 3.3.0(@types/node@26.1.1)(typescript@5.9.3)

--- a/turbo.json
+++ b/turbo.json
@@ -33,6 +33,9 @@
       "dependsOn": ["^topo"],
       "cache": false
     },
+    "changelog:check": {
+      "cache": false
+    },
     "typecheck": {
       "dependsOn": ["^topo", "^build"]
     },


### PR DESCRIPTION
`build`, `docs` and `chore` get proper sections; `ci`, `style` and `test` stop getting them. The 9.0.1 release body is why. It lists 20 dependency and CI chores under `:curly_loop: What a drag! :curly_loop:`, off a `chore` entry the config marks `hidden: true`. The two `docs(ci)` commits in the same range, #298 and #300, are missing from it.

Both come from the `types` array in `packages/modal/.release-it.js`. `docs` and `build` aren't in it, and a type the array doesn't name gets discarded. `hidden` is dead config: conventional-changelog-conventionalcommits 10 reads `effect` and nothing else.

`build` and `docs` change what ships. bunchee's config decides what `dist/` contains, and README.md is packed next to it.

## List

Section names stay in this repo's voice. The two new ones are `:package: Build System :package:` and `:books: Documentation :books:`; `chore` keeps `What a drag!` and is now marked as rendering.

`ci`, `style` and `test` move to hidden under the same rule. `files` is `["dist"]`, so workflows, source formatting and `src/**` tests can't reach a consumer. `ci` had a section of its own until now.

`hidden` is replaced by `effect` everywhere, since that's the field the generator reads. `build`, `docs`, `chore` and `refactor` are all `effect: "changelog"`, so they render without entering the bump count. Only `feat`, `fix`, `perf` and `revert` can raise a version.

The `breaking` entry is gone. Breaking changes reach their heading from a note, so that section could never fill. No commit in this repo has ever used `breaking:` anyway.

![sections before and after](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-modal-changelog-sections/react-native-magic-modal/changelog/modal-sections.png)

## Bump

#261's `tagOpts.prefix` is untouched and is still the only thing keeping the range off the 6.x `v*` tags. Measured over `magic-modal-9.0.1..HEAD` either side of this change, by replaying `@release-it/conventional-changelog`'s `getRecommendedVersion()` against the repo's own config: patch before, patch after, 0 breaking notes, 0 features.

The two patches have different causes. On main the range holds one commit, the `chore(release):` version sync, and the old list let a `chore` bump. On this branch `chore` no longer bumps and the patch comes from this PR's own `fix:` commit.

![bump before and after](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-modal-changelog-sections/react-native-magic-modal/changelog/modal-bump.png)

## Check

`pnpm run changelog:check` builds a throwaway repo with 12 commits, one per type, 3 of them breaking, renders it through the real preset and asserts on what comes back. `ci` is hidden and the `ci!:` commit's breaking note still has to surface. `packages/modal/CHANGELOG.md` has 7 `⚠ BREAKING CHANGES` sections today and every one survives this change.

The check carries its own copy of the policy, so the two disagreeing is a failure. Derived from the preset, every assertion would be a tautology: hide a section and the check quietly redefines what it expected. The negative control in the image is what that failure looks like.

The bump is asserted too: `feat!` major, `feat` minor, `fix` patch, and build/refactor/chore/docs together no release at all.

The type list moves to `packages/modal/tools/changelog-preset.mjs` so `.release-it.js` and the check read the same one. Wired into Branch Checkup, chained onto `pnpm run doctor` since the shared workflow has a single `extra-command`.

![preset check with its negative control](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-modal-changelog-sections/react-native-magic-modal/changelog/modal-controls.png)

## History

release-it prepends into `infile`, so `packages/modal/CHANGELOG.md` below the newest section is never regenerated. Rehearsed on a throwaway clone with publish, push and the GitHub release off: the new section prepends under the header, and `git diff` shows zero lines removed from everything below it, 9.0.1's section included.

No release comes out of this PR. `fix(changelog)` carries no `(modal)` scope and no `!`, and the workflow's "Determine next version" probe returns `skip=true` over the range since #304.

## Scope

The annotated git tag still says "Release ${version}". Giving it the changelog section belongs in the sibling repo. Here `git.push` is `false`, the tag exists only on the release runner, and the GitHub Release creates the ref from scratch, so nothing reads the annotation.
