### PR TITLE
chore(renovate): hold react and the reanimated pair to the Expo SDK line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,20 @@
       "description": "Stricter than the shared preset, which only holds react-native to in-range. packages/modal builds and tests against the same react-native the example app runs, which the Expo SDK dictates. Bumping it on its own installs a second copy and expo-doctor fails on the duplicate. Moves by hand with the SDK.",
       "matchPackageNames": ["react-native", "@react-native/{/,}**"],
       "enabled": false
+    },
+    {
+      "description": "The workspace is hoisted, so whichever react wins the root node_modules is the one packages/modal tests against, whatever any single package.json says. #305 moved react to 19.2.8 for the docs app alone: the example app kept a nested 19.2.0 and expo-doctor stayed quiet, but 19.2.8 hoisted to the root and landed under jest next to the SDK's react-test-renderer 19.2.0, so @testing-library/react-native's peer check killed three of four suites. The shared preset disables react-test-renderer for that exact reason and its Expo rule says react is the SDK's to pick, but the pattern list leaves react and react-dom out. Nothing is given up by holding them: apps/docs is a static export, and 19.2.1 through 19.2.8 are all Server Components and Server Actions. Moves by hand with the SDK.",
+      "matchPackageNames": ["react", "react-dom"],
+      "enabled": false
+    },
+    {
+      "description": "Reanimated and Worklets version-gate each other at runtime and the Expo SDK picks the pair. The file rule above only reaches examples/kitchen-sink, so Renovate kept proposing these on the packages/modal side alone: #306 took reanimated 4.5.3 there, which installed a second copy beside the example app's 4.2.3 and asserted on its `react-native-worklets: 0.10.x - 0.11.x` peer against the SDK's 0.7.4, failing three of four suites. Moving Worklets up to 0.10.3 to match instead fails expo-doctor on the SDK mismatch, since Worklets is not on the example app's expo.install.exclude list. react-native-screens sits in the same position and is held for the same reason. Moves by hand with the SDK.",
+      "matchPackageNames": [
+        "react-native-reanimated",
+        "react-native-worklets",
+        "react-native-screens"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Two Renovate PRs are red on `react-native-magic-modal#test` for the same reason: each moves a version the Expo SDK picks. This adds the rules that stop them being re-proposed. #305 and #306 get closed against it.

## react and react-dom

`renovate.json` already holds react-native, and the shared preset already disables react-test-renderer on the grounds that react's version is the SDK's to pick. The preset's Expo rule never lists react or react-dom though, so they stayed open.

The workspace is hoisted, so whichever react wins the root `node_modules` is the one packages/modal tests against, whatever any single package.json says. #305 only edits `apps/docs/package.json`:

```
root  node_modules/react                 19.2.8   <- docs won the root
root  node_modules/react-test-renderer   19.2.0   <- SDK's, unchanged
examples/kitchen-sink/.../react          19.2.0   <- nested, doctor stays quiet
```

@testing-library/react-native asserts the two match, so three of four suites died before running:

```
Incorrect version of "react-test-renderer" detected.
Expected "19.2.8", but found "19.2.0".
```

react-test-renderer can't follow it up, since the preset disables it.

Holding react costs nothing here. apps/docs is a static export (`next build`, then `serve out`), and 19.2.1 through 19.2.8 are all Server Components and Server Actions changes.

## reanimated, worklets and screens

The example-app file rule only reaches `examples/kitchen-sink/package.json`, so Renovate kept proposing these on the packages/modal side alone. #306 took reanimated 4.5.3 there, which installed a second copy beside the example app's 4.2.3 and then asserted on its own peer:

```
reanimated 4.5.3 peers: react-native-worklets 0.10.x - 0.11.x
expo 55.0.28 ships:     react-native-worklets 0.7.4

[Reanimated] Your installed version of Worklets (0.7.4) is not compatible
with installed version of Reanimated (4.5.3).
```

Moving worklets up to 0.10.3 to satisfy it turns the suites green, 36/36. expo-doctor then fails:

```
X Check that packages match versions required by installed Expo SDK
  package                expected  found
  react-native-worklets  0.7.4     0.10.3
```

Worklets is a native module and isn't on the example app's `expo.install.exclude` list, only reanimated and gesture-handler are. So 4.5.3 cannot land while the repo is on SDK 55. react-native-screens sits in the same position and is held for the same reason.

## Verification

Clean `node_modules`, rebased on main:

- oxlint straight from `node_modules/.bin` in all three workspaces, exit 0. Planted an unused var first to confirm it exits 1.
- format, typecheck, build, doctor 19/19, changelog:check all exit 0
- 36 tests across 4 suites
- `renovate-config-validator` accepts the file

Config only, so no E2E and no release.

Proof, including both reproductions and the worklets experiment: [magic-modal/305-306](https://github.com/GSTJ/pr-assets-dump/tree/magic-modal-305-306-sdk-pins/magic-modal/305-306)

| | |
|---|---|
| [#305 reproduced](https://github.com/GSTJ/pr-assets-dump/blob/magic-modal-305-306-sdk-pins/magic-modal/305-306/305.png) | [#306 reproduced](https://github.com/GSTJ/pr-assets-dump/blob/magic-modal-305-306-sdk-pins/magic-modal/305-306/306.png) |
| [worklets aligned, doctor fails](https://github.com/GSTJ/pr-assets-dump/blob/magic-modal-305-306-sdk-pins/magic-modal/305-306/306-worklets.png) | [chain green here](https://github.com/GSTJ/pr-assets-dump/blob/magic-modal-305-306-sdk-pins/magic-modal/305-306/green.png) |
