### PR TITLE
fix(ci): pin the turbo cache action and gate e2e on writable reviewers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,8 +81,12 @@ jobs:
       - name: 📦 Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      # Same pin as release.yml, and for the same reason. This job carries
+      # `pages: write` and `id-token: write`, so whatever runs here can publish
+      # to the project's Pages site. SHA is v1.3.0, what `v1` already resolved
+      # to.
       - name: 🏗 Setup Turborepo Cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1.3.0
 
       - name: 🛠️ Setup Pages
         uses: actions/configure-pages@v6

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -94,8 +94,8 @@ concurrency:
 jobs:
   # Run the (expensive) macOS build when:
   #   - the PR is opened/updated by the repo owner (GSTJ), OR
-  #   - a reviewer has approved the PR (including subsequent pushes to an
-  #     already-approved PR), OR
+  #   - a reviewer who can write here has approved the PR (including subsequent
+  #     pushes to an already-approved PR), OR
   #   - somebody dispatched the workflow by hand, which already requires write
   #     access to this repository, OR
   #   - the event is a push to main, which is already-reviewed code.
@@ -145,9 +145,20 @@ jobs:
             echo "approved=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Otherwise look up the latest review per reviewer on this PR.
+          # Otherwise look up the latest review on this PR, counting only
+          # reviewers who can write here. This repo is public, so anyone with a
+          # GitHub account can submit an APPROVED review on a fork PR. Without
+          # the author_association filter, two throwaway accounts (one to open,
+          # one to approve) are enough to run 45 minutes of macos-26 on
+          # attacker-controlled code. Nothing is leaked either way, the job has
+          # `contents: read` and no secrets, but it is billed compute.
           STATE=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUM/reviews" \
-            --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")] | sort_by(.submitted_at) | last | .state' \
+            --jq '[.[]
+                   | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")
+                   | select(.author_association=="OWNER"
+                            or .author_association=="MEMBER"
+                            or .author_association=="COLLABORATOR")]
+                  | sort_by(.submitted_at) | last | .state' \
             || echo "")
           if [ "$STATE" = "APPROVED" ]; then
             echo "PR is approved."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,15 @@ jobs:
       - name: 📦 Install Dependencies
         run: pnpm install
 
+      # Pinned to a commit, not the `v1` tag. This is the only third-party
+      # action in the repo that isn't `actions/*` or `pnpm/*`, it sits on a
+      # personal account, and it hasn't been pushed to since June 2024. It also
+      # leaves an HTTP server running on localhost for the rest of the job, and
+      # this job is the one that puts NPM_TOKEN on disk a few steps down. A
+      # mutable tag there means someone else's account decides what runs next to
+      # our publish credentials. SHA is v1.3.0, what `v1` already resolved to.
       - name: 🏗 Setup Turborepo Cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1.3.0
 
       - name: 🛠️ Build
         run: pnpm run build
@@ -211,7 +218,7 @@ jobs:
         run: |
           git config --global user.email "gabrielstaveira@gmail.com"
           git config --global user.name "Gabriel Taveira"
-          npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           pnpm run release
 
       # A release happens rarely, so the steps below it can sit unexecuted for


### PR DESCRIPTION
Came out of auditing the repo for real vulnerabilities alongside the four Dependabot alerts in #309. The library source is clean. These two are in CI.

## The turbo cache action runs next to NPM_TOKEN on a mutable tag

`dtinth/setup-github-actions-caching-for-turbo@v1` is the only third-party action here that isn't `actions/*` or `pnpm/*`. It sits on a personal account and hasn't been pushed to since June 2024. `@v1` is a tag that account can repoint at any time.

In `release.yml` it runs at step 6 of the release job. Fourteen steps later the same job writes the npm publish token to `~/.npmrc` in plaintext and runs `pnpm run release`. It also leaves an HTTP server on localhost:41230 alive for the whole job, as the same UID. Whoever controls that tag controls what is running when the publish credentials hit disk, and this pipeline publishes to npm with no human in the loop.

In `docs.yml` the same action runs in a job holding `pages: write` and `id-token: write`.

Pinned both to `cc723b4600e40a6b8815b65701d8614b91e2669e`, which is v1.3.0 and what `v1` already resolves to, so nothing about the run changes. The 21:05 docs deploy log shows the runner fetching that exact SHA.

Left alone: `actions/*` and `pnpm/*` stay on tags. Those are GitHub-owned and pnpm-owned. Pinning them means 25 more `uses:` lines carrying SHAs across 11 distinct actions, and a Renovate PR for every one of them, against a much smaller reduction.

## Any GitHub account can unlock the 45-minute macOS job

The e2e approval gate reads the PR's reviews and takes the latest APPROVED or CHANGES_REQUESTED, with no filter on who wrote it:

```
--jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")] | sort_by(.submitted_at) | last | .state'
```

This repo is public, so anyone can submit an approving review. Two throwaway accounts, one to open a fork PR and one to approve it, run 45 minutes of `macos-26` on code they wrote.

Nothing leaks. I checked whether this is a pwn request and it isn't: GitHub treats `pull_request_review` on a fork PR the same as `pull_request`, so no secrets reach the runner, `GITHUB_TOKEN` is read-only, the job declares `contents: read` and references no secrets, and the caches are scoped to `refs/pull/N/merge`. The cost is billed compute.

Added an `author_association` filter for OWNER, MEMBER and COLLABORATOR. An outsider's approval now can't override the owner's CHANGES_REQUESTED, and an outsider's approval on its own leaves the gate closed.

Also quoted `"$NPM_TOKEN"` on the `npm config set` line, which clears one shellcheck SC2086.

## Verification

- actionlint over all four workflows. Four findings, all pre-existing, none on a line this touches. The SC2086 that was on the `npm config set` line is gone.
- the jq filter against four hand-built review lists, covering outsider-overrides-owner, outsider-alone, collaborator, and owner
- `v1` dereferences to the pinned SHA, and the last real run fetched the same one

![actionlint, the tag deref and the four gate cases](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/mm-ci-hardening-proof/magic-modal/ci/sec-proof.png)

## Not done here

`release.yml` still does `npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"`, which leaves the token in `~/.npmrc` for the rest of the job. The env-var placeholder form npm supports would keep it out of the file, but that is the publish path and I'm not changing it in the same session as a release. The pin above removes the vector that made it reachable. Worth doing on its own, with a dry run behind it.
