### PR TITLE
fix(docs): polish interactive demos and responsive frames

### DIFF
--- a/apps/docs/app/(home)/home.css
+++ b/apps/docs/app/(home)/home.css
@@ -1237,7 +1237,6 @@ body:has(.magic-home) {
 .mm-section-number,
 .mm-show-heading > span,
 .mm-close-heading > span,
-.mm-history-heading > span,
 .mm-final-copy > span {
   color: var(--mm-muted);
   font-family: "JetBrains Mono Variable", monospace;
@@ -1794,13 +1793,21 @@ body:has(.magic-home) {
 }
 
 .mm-package-modal.is-mobile {
+  aspect-ratio: 9 / 16;
   border: 7px solid #1c1a17;
   border-radius: 40px;
   box-shadow:
     0 0 0 1px #746e64,
     9px 11px 0 #26231e;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100dvh - 2rem);
   max-width: min(390px, calc(100% - 2.5rem));
   overflow: hidden;
+}
+
+.mm-package-modal.is-mobile > :last-child {
+  margin-top: auto;
 }
 
 .mm-package-modal.is-web {
@@ -2360,19 +2367,42 @@ body:has(.magic-home) {
   color: var(--mm-ink);
 }
 
-.mm-example-progress {
-  background: #ddd7cc;
-  height: 7px;
+.mm-example-progress-row {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) 3ch;
   margin-top: 2rem;
-  overflow: hidden;
 }
 
-.mm-example-progress span {
+.mm-example-progress {
+  appearance: none;
+  background: #d7d1c6;
+  border: 1px solid #c4bdb2;
+  height: 9px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.mm-example-progress::-webkit-progress-bar {
+  background: #d7d1c6;
+}
+
+.mm-example-progress::-webkit-progress-value {
   background: var(--mm-blue);
-  display: block;
-  height: 100%;
-  transition: width 180ms ease;
-  width: var(--mm-example-progress, 0%);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--mm-blue) 45%, transparent);
+}
+
+.mm-example-progress::-moz-progress-bar {
+  background: var(--mm-blue);
+}
+
+.mm-example-progress-row output {
+  color: var(--mm-ink);
+  font-family: "JetBrains Mono Variable", monospace;
+  font-size: 0.64rem;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
 .mm-example-result {
@@ -2676,8 +2706,7 @@ body:has(.magic-home) {
 }
 
 .mm-show-heading h2,
-.mm-close-heading h2,
-.mm-history-heading h2 {
+.mm-close-heading h2 {
   font-size: clamp(2.5rem, 4.2vw, 4.35rem);
   font-weight: 590;
   letter-spacing: -0.045em;
@@ -2700,8 +2729,7 @@ body:has(.magic-home) {
 }
 
 .mm-show-heading p,
-.mm-close-heading p,
-.mm-history-heading p {
+.mm-close-heading p {
   font-size: clamp(0.98rem, 1.25vw, 1.12rem);
   line-height: 1.65;
   margin-top: 1.8rem;
@@ -2720,8 +2748,6 @@ body:has(.magic-home) {
   color: var(--mm-paper-bright);
   min-height: 370px;
   padding: clamp(2rem, 4vw, 4.25rem);
-  position: sticky;
-  top: 2rem;
 }
 
 .mm-show-object::before {
@@ -2835,8 +2861,7 @@ body:has(.magic-home) {
   padding-top: 1rem;
 }
 
-.mm-close-heading > span,
-.mm-history-heading > span {
+.mm-close-heading > span {
   color: var(--mm-muted);
 }
 
@@ -2922,6 +2947,22 @@ body:has(.magic-home) {
   background: var(--mm-lime);
 }
 
+.mm-result-controls button:disabled {
+  cursor: default;
+  opacity: 0.48;
+}
+
+.mm-result-controls button[aria-pressed="true"]:disabled {
+  opacity: 1;
+}
+
+.mm-result-controls .mm-result-reset {
+  background: var(--mm-paper-bright);
+  border-color: var(--mm-ink);
+  color: var(--mm-ink);
+  font-weight: 680;
+}
+
 .mm-result-lab:not([data-reason="INTENTIONAL_HIDE"]):not(
     [data-reason="pending"]
   )
@@ -2969,6 +3010,7 @@ body:has(.magic-home) {
   padding-top: 1rem;
   position: absolute;
   top: 3rem;
+  transition: opacity 180ms ease;
   width: 29%;
 }
 
@@ -2981,16 +3023,65 @@ body:has(.magic-home) {
   min-height: 245px;
   padding: 1rem 1.1rem 1.2rem;
   position: relative;
+  transform: translateY(var(--mm-result-drag-y, 0));
+  transform-origin: bottom center;
+  transition: transform 180ms ease;
   z-index: 2;
 }
 
-.mm-result-sheet > span {
-  background: var(--mm-line);
-  border-radius: 99px;
-  display: block;
-  height: 4px;
-  margin: 0 auto 2.2rem;
-  width: 36px;
+.mm-result-sheet[data-dragging="true"] {
+  transition: none;
+}
+
+.mm-result-lab[data-visual="closing"] .mm-result-backdrop {
+  opacity: 0.22;
+  pointer-events: none;
+}
+
+.mm-result-lab[data-visual="closed"] .mm-result-backdrop {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.mm-result-lab[data-visual="closing"] .mm-result-sheet {
+  animation: mm-result-sheet-close 280ms cubic-bezier(0.4, 0, 1, 1) both;
+  pointer-events: none;
+}
+
+.mm-result-lab[data-visual="closing"][data-reason="SWIPE_COMPLETE"]
+  .mm-result-sheet {
+  animation-name: mm-result-sheet-swipe;
+}
+
+.mm-result-lab[data-visual="closed"] .mm-result-sheet {
+  align-self: center;
+  background: var(--mm-paper-bright);
+  border-color: var(--mm-ink);
+  border-radius: 0;
+  border-style: dashed;
+  box-shadow: none;
+  min-height: 180px;
+}
+
+.mm-result-closed {
+  align-content: center;
+  display: grid;
+  min-height: 150px;
+  text-align: center;
+}
+
+.mm-result-closed strong {
+  color: var(--mm-ink);
+  font-size: 0.9rem;
+}
+
+.mm-result-closed span {
+  color: var(--mm-muted);
+  font-size: 0.66rem;
+  line-height: 1.5;
+  margin: 0.45rem auto 0;
+  max-width: 170px;
 }
 
 .mm-result-sheet strong {
@@ -3017,6 +3108,37 @@ body:has(.magic-home) {
   margin-top: 1.4rem;
   min-height: 42px;
   width: 100%;
+}
+
+.mm-result-sheet button:disabled {
+  cursor: default;
+}
+
+.mm-result-sheet .mm-result-drag-handle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  cursor: grab;
+  display: flex;
+  height: 28px;
+  justify-content: center;
+  margin: -0.45rem auto 1.55rem;
+  min-height: 28px;
+  padding: 0;
+  touch-action: none;
+  width: 64px;
+}
+
+.mm-result-sheet .mm-result-drag-handle:active {
+  cursor: grabbing;
+}
+
+.mm-result-drag-handle span {
+  background: var(--mm-line);
+  border-radius: 99px;
+  display: block;
+  height: 4px;
+  width: 36px;
 }
 
 .mm-result-path {
@@ -3070,6 +3192,7 @@ body:has(.magic-home) {
   background: var(--mm-ink);
   box-shadow: 10px 10px 0 color-mix(in srgb, var(--mm-blue) 85%, transparent);
   color: var(--mm-paper-bright);
+  margin-right: 10px;
   min-height: 270px;
   padding: 1rem;
   position: relative;
@@ -3153,101 +3276,6 @@ body:has(.magic-home) {
 
 .mm-result-receipt pre {
   animation: mm-receipt 280ms ease both;
-}
-
-.mm-history {
-  border-top: 1px solid var(--mm-line);
-  margin: 0 auto;
-  max-width: 1600px;
-  padding: clamp(7rem, 11vw, 11rem) clamp(1.5rem, 7vw, 7rem);
-}
-
-.mm-history-heading {
-  display: grid;
-  gap: 1rem clamp(2rem, 8vw, 8rem);
-  grid-template-columns: 0.82fr 1.18fr;
-  margin-bottom: clamp(4rem, 7vw, 7rem);
-}
-
-.mm-history-heading > span {
-  grid-column: 1 / -1;
-}
-
-.mm-history-heading h2 {
-  max-width: 720px;
-}
-
-.mm-history-heading p {
-  align-self: end;
-  color: var(--mm-muted);
-  max-width: 490px;
-}
-
-.mm-history-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.mm-history-list li {
-  border-top: 1px solid var(--mm-ink);
-}
-
-.mm-history-list li:last-child {
-  border-bottom: 1px solid var(--mm-ink);
-}
-
-.mm-history-list a {
-  align-items: start;
-  display: grid;
-  gap: 1rem clamp(1.5rem, 4vw, 4.5rem);
-  grid-template-columns: 0.45fr 0.44fr 0.92fr 1.45fr 20px;
-  min-height: 180px;
-  padding: 2.1rem 0;
-  transition:
-    background 180ms ease,
-    padding 180ms ease;
-}
-
-.mm-history-list a:hover {
-  background: var(--mm-paper-bright);
-  padding-inline: 1.2rem;
-}
-
-.mm-history-year {
-  color: var(--mm-coral);
-  font-family: "Instrument Serif", serif;
-  font-size: clamp(3rem, 4.7vw, 4.8rem);
-  font-style: italic;
-  line-height: 0.8;
-}
-
-.mm-history-date {
-  color: var(--mm-muted);
-  font-family: "JetBrains Mono Variable", monospace;
-  font-size: 0.58rem;
-  padding-top: 0.22rem;
-}
-
-.mm-history-list strong {
-  font-size: clamp(1.2rem, 1.7vw, 1.55rem);
-  letter-spacing: -0.04em;
-  line-height: 1.05;
-}
-
-.mm-history-list p {
-  color: var(--mm-muted);
-  font-size: 0.84rem;
-  line-height: 1.6;
-  max-width: 520px;
-}
-
-.mm-history-list svg {
-  transition: transform 160ms ease;
-}
-
-.mm-history-list a:hover svg {
-  transform: translate(3px, -3px);
 }
 
 .mm-final {
@@ -3604,8 +3632,7 @@ body:has(.magic-home) {
 
 .mm-hero h1,
 .mm-request-copy h2,
-.mm-close-heading h2,
-.mm-history-heading h2 {
+.mm-close-heading h2 {
   color: var(--mm-fg);
 }
 
@@ -3616,11 +3643,7 @@ body:has(.magic-home) {
 .mm-request-copy aside p,
 .mm-examples > header > span,
 .mm-examples > header p,
-.mm-close-heading > span,
-.mm-history-heading > span,
-.mm-history-heading p,
-.mm-history-list p,
-.mm-history-date {
+.mm-close-heading > span {
   color: var(--mm-fg-muted) !important;
 }
 
@@ -3747,19 +3770,6 @@ body:has(.magic-home) {
   border-color: var(--mm-canvas);
 }
 
-.mm-history {
-  border-color: var(--mm-dark-line);
-}
-
-.mm-history-list li,
-.mm-history-list li:last-child {
-  border-color: var(--mm-dark-line);
-}
-
-.mm-history-list a:hover {
-  background: var(--mm-surface);
-}
-
 .mm-final .mh-install-command {
   border-color: color-mix(in srgb, var(--mm-ink) 42%, transparent);
   color: var(--mm-ink);
@@ -3806,6 +3816,20 @@ body:has(.magic-home) {
   }
 }
 
+@keyframes mm-result-sheet-close {
+  to {
+    opacity: 0;
+    transform: translateY(22px) scale(0.98);
+  }
+}
+
+@keyframes mm-result-sheet-swipe {
+  to {
+    opacity: 0;
+    transform: translateY(115%);
+  }
+}
+
 @media (max-width: 1280px) {
   .mm-hero {
     gap: 2rem;
@@ -3832,6 +3856,20 @@ body:has(.magic-home) {
   .mm-show,
   .mm-close {
     gap: 4rem;
+  }
+}
+
+@media (max-width: 1080px) {
+  .mm-close {
+    grid-template-columns: 1fr;
+  }
+
+  .mm-close-heading {
+    max-width: 700px;
+  }
+
+  .mm-close > div:last-child {
+    width: 100%;
   }
 }
 
@@ -3967,9 +4005,23 @@ body:has(.magic-home) {
   .mm-close > div:last-child {
     width: 100%;
   }
+}
 
-  .mm-history-list a {
-    grid-template-columns: 0.38fr 0.52fr 1fr 1.35fr 20px;
+@media (min-width: 701px) and (max-width: 860px) {
+  .mm-example-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .mm-example-code {
+    justify-self: center;
+    max-width: 620px;
+    width: 100%;
+  }
+
+  .mm-example-preview {
+    justify-self: center;
+    max-width: 360px;
+    width: 100%;
   }
 }
 
@@ -4109,7 +4161,7 @@ body:has(.magic-home) {
   }
 
   .mm-origin-flow {
-    height: 420px;
+    height: 584px;
     margin-top: 2rem;
     min-height: 0;
   }
@@ -4119,7 +4171,7 @@ body:has(.magic-home) {
   }
 
   .mm-flow-code {
-    bottom: -44px;
+    bottom: 0;
     box-shadow: 7px 7px 0 var(--mm-coral);
     height: 48px;
     left: 1.7rem;
@@ -4169,7 +4221,7 @@ body:has(.magic-home) {
     box-shadow:
       0 22px 48px rgba(31, 26, 19, 0.2),
       -6px 7px 0 var(--mm-blue);
-    height: 402px;
+    height: 520px;
     left: 1.7rem;
     min-height: 0;
     padding: 36px 10px 38px;
@@ -4432,8 +4484,7 @@ body:has(.magic-home) {
 
   .mm-owner,
   .mm-show,
-  .mm-close,
-  .mm-history {
+  .mm-close {
     padding: 6.5rem 1.7rem;
   }
 
@@ -4448,15 +4499,13 @@ body:has(.magic-home) {
 
   .mm-section-copy h2,
   .mm-show-heading h2,
-  .mm-close-heading h2,
-  .mm-history-heading h2 {
+  .mm-close-heading h2 {
     font-size: clamp(2.2rem, 9.5vw, 2.8rem);
   }
 
   .mm-section-copy > p,
   .mm-show-heading p,
-  .mm-close-heading p,
-  .mm-history-heading p {
+  .mm-close-heading p {
     font-size: 0.94rem;
   }
 
@@ -4585,12 +4634,15 @@ body:has(.magic-home) {
 
   .mm-result-sheet {
     min-height: 220px;
+    position: relative;
     width: 72%;
+    z-index: 1;
   }
 
   .mm-result-path {
     height: 90px;
     margin-left: 36%;
+    z-index: 2;
     width: 1px;
   }
 
@@ -4626,45 +4678,8 @@ body:has(.magic-home) {
   .mm-result-receipt {
     margin-left: 10%;
     min-height: 255px;
-    width: 90%;
-  }
-
-  .mm-history-heading {
-    display: block;
-    margin-bottom: 4rem;
-  }
-
-  .mm-history-heading h2 {
-    margin-top: 1.2rem;
-  }
-
-  .mm-history-list a {
-    gap: 0.8rem 1rem;
-    grid-template-columns: 0.6fr 1.4fr 20px;
-    min-height: 0;
-    padding: 2rem 0;
-  }
-
-  .mm-history-year {
-    font-size: 3.2rem;
-    grid-row: 1 / 3;
-  }
-
-  .mm-history-date {
-    grid-column: 2;
-  }
-
-  .mm-history-list strong {
-    grid-column: 2;
-  }
-
-  .mm-history-list p {
-    grid-column: 1 / -1;
-  }
-
-  .mm-history-list svg {
-    grid-column: 3;
-    grid-row: 1;
+    z-index: 2;
+    width: calc(90% - 10px);
   }
 
   .mm-final {
@@ -5021,8 +5036,11 @@ body:has(.magic-home) {
   .mm-result-backdrop {
     bottom: auto;
     height: 220px;
+    justify-content: flex-end;
+    padding-right: 0.65rem;
+    text-align: right;
     top: 3rem;
-    width: 72%;
+    width: 100%;
   }
 
   .mm-footer {

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -24,30 +24,6 @@ import {
 } from "@/components/project-metadata-values";
 import { ResultLab } from "@/components/result-lab";
 
-const history = [
-  {
-    href: "https://github.com/GSTJ/react-native-magic-modal/commit/64612c8",
-    isoDate: "2022-02-21T00:00:00.000Z",
-    title: "First release.",
-    description:
-      "show() moved visibility state out of the screen and returned a value when the modal closed.",
-  },
-  {
-    href: "https://github.com/GSTJ/react-native-magic-modal/pull/81",
-    isoDate: "2024-06-08T00:00:00.000Z",
-    title: "Stacks and typed close reasons.",
-    description:
-      "Each entry gained its own ID and promise. This release also added hideAll(), swipe gestures, and the iOS full-window overlay.",
-  },
-  {
-    href: "https://github.com/GSTJ/react-native-magic-modal/releases/tag/magic-modal-9.0.0",
-    isoDate: "2026-07-27T00:00:00.000Z",
-    title: "In-place updates and Gesture Handler 3.",
-    description:
-      "update() can replace an open modal in place. Swipe dismissal now supports Gesture Handler 2 and 3.",
-  },
-] as const;
-
 const ratingCallers = [
   "post.tsx",
   "comment.tsx",
@@ -61,16 +37,6 @@ const repeatedRatingState = [
   "isStoreReviewOpen",
   "isThanksOpen",
 ] as const;
-
-const formatMilestone = (isoDate: string) =>
-  new Intl.DateTimeFormat("en-US", {
-    day: "2-digit",
-    month: "short",
-    timeZone: "UTC",
-    year: "numeric",
-  })
-    .format(new Date(isoDate))
-    .toUpperCase();
 
 export default function HomePage() {
   return (
@@ -419,36 +385,6 @@ export default function HomePage() {
         <div data-reveal>
           <ResultLab />
         </div>
-      </section>
-
-      <section className="mm-history">
-        <div className="mm-history-heading" data-reveal>
-          <span>RELEASE HISTORY</span>
-          <h2>How the API changed</h2>
-          <p>
-            Apps needed stacked modals, targeted updates, typed close reasons,
-            native overlays, and support for newer gesture APIs.
-          </p>
-        </div>
-
-        <ol className="mm-history-list">
-          {history.map(({ description, href, isoDate, title }) => {
-            const year = new Date(isoDate).getUTCFullYear();
-            return (
-              <li data-reveal key={isoDate}>
-                <a href={href} rel="noreferrer" target="_blank">
-                  <span className="mm-history-year">{year}</span>
-                  <span className="mm-history-date">
-                    {formatMilestone(isoDate)}
-                  </span>
-                  <strong>{title}</strong>
-                  <p>{description}</p>
-                  <ArrowUpRight aria-hidden="true" size={17} />
-                </a>
-              </li>
-            );
-          })}
-        </ol>
       </section>
 
       <section className="mm-final">

--- a/apps/docs/components/practical-examples.tsx
+++ b/apps/docs/components/practical-examples.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import type { CSSProperties, MouseEvent } from "react";
+import type { NewConfigProps } from "react-native-magic-modal";
+
+import type { MouseEvent } from "react";
 
 import {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
 
 import { gsap } from "gsap";
 import { ArrowRight, Check, Upload } from "lucide-react";
+import { MagicModalHideReason, magicModal } from "react-native-magic-modal";
 
 type ExampleID = "confirm" | "follow-up" | "update";
 type ExamplePhase =
@@ -32,6 +34,23 @@ type Example = {
   note: string;
   type: ExampleID;
 };
+
+type UploadResult = "cancelled" | "done";
+type UploadHandle = ReturnType<typeof magicModal.show<UploadResult>>;
+
+const uploadCheckpointSize = 25;
+
+const uploadModalConfig = {
+  animationInTiming: 0,
+  animationOutTiming: 0,
+  hideBackdrop: true,
+  style: { display: "none" },
+  swipeDirection: undefined,
+} satisfies NewConfigProps;
+
+const UploadCheckpoint = ({ progress }: { progress: number }) => (
+  <span aria-hidden="true" data-magic-modal-upload-progress={progress} hidden />
+);
 
 const confirmExample: Example = {
   code: `const result = await magicModal
@@ -101,11 +120,7 @@ const nextExample: Record<Exclude<ExampleID, "update">, ExampleID> = {
   "follow-up": "update",
 };
 
-const getPreview = (
-  activeID: ExampleID,
-  phase: ExamplePhase,
-  progress: number,
-) => {
+const getPreview = (activeID: ExampleID, phase: ExamplePhase) => {
   if (activeID === "confirm") {
     if (phase === "resolved") {
       return {
@@ -156,10 +171,10 @@ const getPreview = (
 
   if (phase === "uploading") {
     return {
-      action: `Uploading ${progress}%`,
+      action: "Uploading",
       body: "update() remounts the sheet at each checkpoint.",
       disabled: true,
-      result: `${progress}% | promise pending`,
+      result: "Promise pending",
       title: "Upload in progress",
     };
   }
@@ -168,7 +183,7 @@ const getPreview = (
       action: "Close modal",
       body: "The upload finished. The same promise is still pending.",
       disabled: false,
-      result: "100% | promise pending",
+      result: "Promise pending",
       title: "Upload complete",
     };
   }
@@ -185,7 +200,7 @@ const getPreview = (
     action: "Start upload",
     body: "video-final.mp4",
     disabled: false,
-    result: "0% | promise pending",
+    result: "Promise pending",
     title: "Ready to upload",
   };
 };
@@ -195,14 +210,52 @@ export const PracticalExamples = () => {
   const [phase, setPhase] = useState<ExamplePhase>("ready");
   const [progress, setProgress] = useState(0);
   const panelRef = useRef<HTMLDivElement>(null);
+  const progressBarRef = useRef<HTMLProgressElement>(null);
+  const uploadHandleRef = useRef<UploadHandle | null>(null);
+  const uploadRunRef = useRef(0);
+  const uploadTweenRef = useRef<ReturnType<typeof gsap.to> | null>(null);
+  const mountedRef = useRef(true);
   const active = findExample(activeID);
-  const preview = getPreview(activeID, phase, progress);
+  const preview = getPreview(activeID, phase);
 
-  const openExample = useCallback((id: ExampleID) => {
-    setActiveID(id);
-    setPhase("ready");
-    setProgress(0);
+  const stopUpload = useCallback(() => {
+    uploadRunRef.current += 1;
+    uploadTweenRef.current?.kill();
+    uploadTweenRef.current = null;
+
+    if (progressBarRef.current) {
+      progressBarRef.current.value = 0;
+    }
+
+    const handle = uploadHandleRef.current;
+    uploadHandleRef.current = null;
+
+    if (handle) {
+      try {
+        magicModal.hide<UploadResult>("cancelled", {
+          modalID: handle.modalID,
+        });
+      } catch (error) {
+        const portalUnmounted =
+          error instanceof Error &&
+          error.message.includes("MagicModalPortal not found");
+
+        if (!portalUnmounted) {
+          throw error;
+        }
+      }
+    }
   }, []);
+
+  const openExample = useCallback(
+    (id: ExampleID) => {
+      stopUpload();
+      setActiveID(id);
+      setPhase("ready");
+      setProgress(0);
+    },
+    [stopUpload],
+  );
 
   const selectExample = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
@@ -210,6 +263,108 @@ export const PracticalExamples = () => {
     },
     [openExample],
   );
+
+  const startUpload = useCallback(() => {
+    stopUpload();
+
+    const runID = uploadRunRef.current;
+    const handle = magicModal.show<UploadResult>(
+      () => <UploadCheckpoint progress={0} />,
+      uploadModalConfig,
+    );
+
+    uploadHandleRef.current = handle;
+    setProgress(0);
+    setPhase("uploading");
+
+    void handle.promise.then((result) => {
+      if (!mountedRef.current || uploadRunRef.current !== runID) {
+        return;
+      }
+
+      uploadHandleRef.current = null;
+      uploadTweenRef.current?.kill();
+      uploadTweenRef.current = null;
+
+      if (
+        result.reason === MagicModalHideReason.INTENTIONAL_HIDE &&
+        result.data === "done"
+      ) {
+        setPhase("complete");
+        return;
+      }
+
+      if (progressBarRef.current) {
+        progressBarRef.current.value = 0;
+      }
+      setProgress(0);
+      setPhase("ready");
+    });
+
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    if (reduceMotion) {
+      if (progressBarRef.current) {
+        progressBarRef.current.value = 100;
+      }
+      handle.update(() => <UploadCheckpoint progress={100} />);
+      setProgress(100);
+      setPhase("uploaded");
+      return;
+    }
+
+    const animatedProgress = { value: 0 };
+    let lastCheckpoint = 0;
+    let lastProgress = 0;
+
+    if (progressBarRef.current) {
+      progressBarRef.current.value = 0;
+    }
+
+    uploadTweenRef.current = gsap.to(animatedProgress, {
+      duration: 2.8,
+      ease: "power2.inOut",
+      onComplete: () => {
+        if (!mountedRef.current || uploadRunRef.current !== runID) {
+          return;
+        }
+
+        if (lastCheckpoint < 100) {
+          handle.update(() => <UploadCheckpoint progress={100} />);
+        }
+        setProgress(100);
+        setPhase("uploaded");
+        uploadTweenRef.current = null;
+      },
+      onUpdate: () => {
+        if (!mountedRef.current || uploadRunRef.current !== runID) {
+          return;
+        }
+
+        const nextProgress = Math.round(animatedProgress.value);
+        const nextCheckpoint =
+          Math.floor(nextProgress / uploadCheckpointSize) *
+          uploadCheckpointSize;
+
+        if (progressBarRef.current) {
+          progressBarRef.current.value = animatedProgress.value;
+        }
+
+        if (nextProgress !== lastProgress) {
+          lastProgress = nextProgress;
+          setProgress(nextProgress);
+        }
+
+        if (nextCheckpoint > lastCheckpoint) {
+          lastCheckpoint = nextCheckpoint;
+          handle.update(() => <UploadCheckpoint progress={nextCheckpoint} />);
+        }
+      },
+      value: 100,
+    });
+  }, [stopUpload]);
 
   const runPreview = useCallback(() => {
     if (activeID === "confirm") {
@@ -222,16 +377,24 @@ export const PracticalExamples = () => {
       return;
     }
     if (phase === "ready") {
-      setProgress(0);
-      setPhase("uploading");
+      startUpload();
       return;
     }
     if (phase === "uploaded") {
-      setPhase("complete");
+      const handle = uploadHandleRef.current;
+
+      if (!handle) {
+        setPhase("complete");
+        return;
+      }
+
+      magicModal.hide<UploadResult>("done", {
+        modalID: handle.modalID,
+      });
       return;
     }
     if (phase === "complete") openExample("confirm");
-  }, [activeID, openExample, phase]);
+  }, [activeID, openExample, phase, startUpload]);
 
   useEffect(() => {
     if (activeID === "confirm" && phase === "resolved") {
@@ -254,30 +417,14 @@ export const PracticalExamples = () => {
     }
   }, [activeID, openExample, phase]);
 
-  const progressStyle = useMemo(
-    () =>
-      ({
-        "--mm-example-progress": `${progress}%`,
-      }) as CSSProperties,
-    [progress],
-  );
-
   useEffect(() => {
-    if (activeID !== "update" || phase !== "uploading") return;
+    mountedRef.current = true;
 
-    const interval = window.setInterval(() => {
-      setProgress((current) => {
-        const next = Math.min(current + 8, 100);
-        if (next === 100) {
-          window.clearInterval(interval);
-          window.setTimeout(() => setPhase("uploaded"), 260);
-        }
-        return next;
-      });
-    }, 110);
-
-    return () => window.clearInterval(interval);
-  }, [activeID, phase]);
+    return () => {
+      mountedRef.current = false;
+      stopUpload();
+    };
+  }, [stopUpload]);
 
   useLayoutEffect(() => {
     if (!panelRef.current) return;
@@ -386,12 +533,20 @@ export const PracticalExamples = () => {
               <h3>{preview.title}</h3>
               <p>{preview.body}</p>
               {active.type === "update" && (
-                <div
-                  aria-label={`${progress}% uploaded`}
-                  className="mm-example-progress"
-                  style={progressStyle}
-                >
-                  <span />
+                <div className="mm-example-progress-row">
+                  <progress
+                    aria-label="Upload progress"
+                    aria-valuetext={`${progress}% uploaded. ${
+                      phase === "complete"
+                        ? "Promise resolved."
+                        : "Promise pending."
+                    }`}
+                    className="mm-example-progress"
+                    max={100}
+                    ref={progressBarRef}
+                    value={progress}
+                  />
+                  <output aria-hidden="true">{progress}%</output>
                 </div>
               )}
               <button

--- a/apps/docs/components/result-lab.tsx
+++ b/apps/docs/components/result-lab.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import type { MouseEvent } from "react";
+import type { HideReturn } from "react-native-magic-modal";
 
-import { useCallback, useState } from "react";
+import type { AnimationEvent, MouseEvent, PointerEvent } from "react";
 
-type CloseReason =
-  | "BACKDROP_PRESS"
-  | "BACK_BUTTON_PRESS"
-  | "GLOBAL_HIDE_ALL"
-  | "INTENTIONAL_HIDE"
-  | "SWIPE_COMPLETE";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { MagicModalHideReason } from "react-native-magic-modal";
+
+type Answer = { answer: number };
+type CloseReason = HideReturn<Answer>["reason"];
+type LabPhase = "pending" | "resolved";
+type VisualPhase = "closed" | "closing" | "open";
 
 const outcomes: {
   reason: CloseReason;
@@ -17,27 +19,27 @@ const outcomes: {
   trigger: string;
 }[] = [
   {
-    reason: "INTENTIONAL_HIDE",
+    reason: MagicModalHideReason.INTENTIONAL_HIDE,
     short: "answer",
     trigger: "hide({ answer: 42 })",
   },
   {
-    reason: "BACKDROP_PRESS",
+    reason: MagicModalHideReason.BACKDROP_PRESS,
     short: "backdrop",
     trigger: "tap the live backdrop",
   },
   {
-    reason: "SWIPE_COMPLETE",
+    reason: MagicModalHideReason.SWIPE_COMPLETE,
     short: "swipe",
     trigger: "complete the swipe",
   },
   {
-    reason: "BACK_BUTTON_PRESS",
+    reason: MagicModalHideReason.BACK_BUTTON_PRESS,
     short: "Android back",
     trigger: "simulate the Android system back action",
   },
   {
-    reason: "GLOBAL_HIDE_ALL",
+    reason: MagicModalHideReason.GLOBAL_HIDE_ALL,
     short: "hideAll",
     trigger: "magicModal.hideAll()",
   },
@@ -47,28 +49,235 @@ const triggerByReason = Object.fromEntries(
   outcomes.map(({ reason, trigger }) => [reason, trigger]),
 ) as Record<CloseReason, string>;
 
+const createResult = (reason: CloseReason): HideReturn<Answer> =>
+  reason === MagicModalHideReason.INTENTIONAL_HIDE
+    ? { data: { answer: 42 }, reason }
+    : { reason };
+
 export const ResultLab = () => {
-  const [reason, setReason] = useState<CloseReason | null>(null);
-  const hasData = reason === "INTENTIONAL_HIDE";
-  const selectReason = useCallback((event: MouseEvent<HTMLButtonElement>) => {
-    setReason(event.currentTarget.dataset.reason as CloseReason);
+  const closingTimer = useRef<number | null>(null);
+  const closingReason = useRef<CloseReason | null>(null);
+  const dragDistance = useRef(0);
+  const dragStartY = useRef<number | null>(null);
+  const locked = useRef(false);
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const [phase, setPhase] = useState<LabPhase>("pending");
+  const [result, setResult] = useState<HideReturn<Answer> | null>(null);
+  const [selectedReason, setSelectedReason] = useState<CloseReason | null>(
+    null,
+  );
+  const [visualPhase, setVisualPhase] = useState<VisualPhase>("open");
+  const hasData = result?.reason === MagicModalHideReason.INTENTIONAL_HIDE;
+  const controlsLocked = visualPhase !== "open";
+
+  const finishClose = useCallback(() => {
+    const reason = closingReason.current;
+
+    if (reason === null) {
+      return;
+    }
+
+    closingReason.current = null;
+
+    if (closingTimer.current !== null) {
+      window.clearTimeout(closingTimer.current);
+      closingTimer.current = null;
+    }
+
+    if (reason === MagicModalHideReason.SWIPE_COMPLETE) {
+      setResult(createResult(reason));
+      setPhase("resolved");
+    }
+
+    dragDistance.current = 0;
+    dragStartY.current = null;
+    if (sheetRef.current) {
+      delete sheetRef.current.dataset.dragging;
+    }
+    sheetRef.current?.style.removeProperty("--mm-result-drag-y");
+    setVisualPhase("closed");
   }, []);
-  const answer = useCallback(() => setReason("INTENTIONAL_HIDE"), []);
-  const closeFromBackdrop = useCallback(() => setReason("BACKDROP_PRESS"), []);
+
+  const resolve = useCallback(
+    (nextReason: CloseReason) => {
+      if (locked.current) {
+        return;
+      }
+
+      locked.current = true;
+      closingReason.current = nextReason;
+      setSelectedReason(nextReason);
+      setVisualPhase("closing");
+
+      if (nextReason !== MagicModalHideReason.SWIPE_COMPLETE) {
+        setResult(createResult(nextReason));
+        setPhase("resolved");
+      }
+
+      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        finishClose();
+        return;
+      }
+
+      closingTimer.current = window.setTimeout(finishClose, 500);
+    },
+    [finishClose],
+  );
+
+  const finishFromAnimation = useCallback(
+    (event: AnimationEvent<HTMLDivElement>) => {
+      if (event.currentTarget === event.target) {
+        finishClose();
+      }
+    },
+    [finishClose],
+  );
+
+  const startSwipe = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+    if (locked.current || !event.isPrimary || event.button !== 0) {
+      return;
+    }
+
+    dragStartY.current = event.clientY;
+    dragDistance.current = 0;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    if (sheetRef.current) {
+      sheetRef.current.dataset.dragging = "true";
+    }
+  }, []);
+
+  const moveSwipe = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+    if (dragStartY.current === null || !event.isPrimary) {
+      return;
+    }
+
+    const distance = Math.max(0, event.clientY - dragStartY.current);
+    dragDistance.current = distance;
+    sheetRef.current?.style.setProperty(
+      "--mm-result-drag-y",
+      `${Math.min(distance, 180)}px`,
+    );
+  }, []);
+
+  const cancelSwipe = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+    dragStartY.current = null;
+    dragDistance.current = 0;
+    if (sheetRef.current) {
+      delete sheetRef.current.dataset.dragging;
+    }
+    sheetRef.current?.style.setProperty("--mm-result-drag-y", "0px");
+
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const endSwipe = useCallback(
+    (event: PointerEvent<HTMLButtonElement>) => {
+      if (dragStartY.current === null) {
+        return;
+      }
+
+      const shouldClose = dragDistance.current >= 72;
+      dragStartY.current = null;
+      dragDistance.current = 0;
+
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+
+      if (shouldClose) {
+        resolve(MagicModalHideReason.SWIPE_COMPLETE);
+        return;
+      }
+
+      if (sheetRef.current) {
+        delete sheetRef.current.dataset.dragging;
+      }
+      sheetRef.current?.style.setProperty("--mm-result-drag-y", "0px");
+    },
+    [resolve],
+  );
+
+  const activateSwipeWithKeyboard = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (event.detail === 0) {
+        resolve(MagicModalHideReason.SWIPE_COMPLETE);
+      }
+    },
+    [resolve],
+  );
+
+  const selectReason = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      resolve(event.currentTarget.dataset.reason as CloseReason);
+    },
+    [resolve],
+  );
+  const answer = useCallback(
+    () => resolve(MagicModalHideReason.INTENTIONAL_HIDE),
+    [resolve],
+  );
+  const closeFromBackdrop = useCallback(
+    () => resolve(MagicModalHideReason.BACKDROP_PRESS),
+    [resolve],
+  );
+  const reset = useCallback(() => {
+    if (closingTimer.current !== null) {
+      window.clearTimeout(closingTimer.current);
+      closingTimer.current = null;
+    }
+    locked.current = false;
+    closingReason.current = null;
+    dragDistance.current = 0;
+    dragStartY.current = null;
+    if (sheetRef.current) {
+      delete sheetRef.current.dataset.dragging;
+    }
+    sheetRef.current?.style.removeProperty("--mm-result-drag-y");
+    setResult(null);
+    setSelectedReason(null);
+    setPhase("pending");
+    setVisualPhase("open");
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (closingTimer.current !== null) {
+        window.clearTimeout(closingTimer.current);
+      }
+    },
+    [],
+  );
+
   let receiptState = "promise pending";
-  if (reason !== null) {
+  if (phase === "resolved") {
     receiptState = hasData ? "with data" : "reason only";
   }
 
+  let controlsLabel = "Choose one close action";
+  if (visualPhase === "closing") {
+    controlsLabel = "Modal closing";
+  }
+  if (phase === "resolved") {
+    controlsLabel = "Promise resolved";
+  }
+
   return (
-    <div className="mm-result-lab" data-reason={reason ?? "pending"}>
+    <div
+      className="mm-result-lab"
+      data-phase={phase}
+      data-reason={selectedReason ?? "pending"}
+      data-visual={visualPhase}
+    >
       <div className="mm-result-controls">
-        <span>Trigger any close path</span>
-        <fieldset aria-label="Trigger a modal close path">
+        <span>{controlsLabel}</span>
+        <fieldset aria-label="Choose how the modal closes">
           {outcomes.map((outcome) => (
             <button
-              aria-pressed={reason === outcome.reason}
+              aria-pressed={selectedReason === outcome.reason}
               data-reason={outcome.reason}
+              disabled={controlsLocked}
               key={outcome.reason}
               onClick={selectReason}
               type="button"
@@ -77,6 +286,11 @@ export const ResultLab = () => {
               {outcome.short}
             </button>
           ))}
+          {phase === "resolved" && visualPhase === "closed" && (
+            <button className="mm-result-reset" onClick={reset} type="button">
+              Try another close action
+            </button>
+          )}
         </fieldset>
       </div>
 
@@ -84,18 +298,44 @@ export const ResultLab = () => {
         <button
           aria-label="Close the modal by pressing its backdrop"
           className="mm-result-backdrop"
+          disabled={controlsLocked}
           onClick={closeFromBackdrop}
           type="button"
         >
-          tap backdrop
+          backdrop
         </button>
-        <div className="mm-result-sheet">
-          <span />
-          <strong>Choose an answer</strong>
-          <p>Answer from the sheet or dismiss it another way.</p>
-          <button onClick={answer} type="button">
-            Answer 42
-          </button>
+        <div
+          className="mm-result-sheet"
+          onAnimationEnd={finishFromAnimation}
+          ref={sheetRef}
+        >
+          {visualPhase === "closed" ? (
+            <div className="mm-result-closed">
+              <strong>Modal closed</strong>
+              <span>Each modal starts with its own promise.</span>
+            </div>
+          ) : (
+            <>
+              <button
+                aria-label="Close the modal with a swipe"
+                className="mm-result-drag-handle"
+                disabled={controlsLocked}
+                onClick={activateSwipeWithKeyboard}
+                onPointerCancel={cancelSwipe}
+                onPointerDown={startSwipe}
+                onPointerMove={moveSwipe}
+                onPointerUp={endSwipe}
+                type="button"
+              >
+                <span />
+              </button>
+              <strong>Choose an answer</strong>
+              <p>Answer here, swipe down, or choose another close action.</p>
+              <button disabled={controlsLocked} onClick={answer} type="button">
+                Answer 42
+              </button>
+            </>
+          )}
         </div>
         <div className="mm-result-path" aria-hidden="true">
           <span />
@@ -106,34 +346,42 @@ export const ResultLab = () => {
             <span>HideReturn&lt;Answer&gt;</span>
             <code>{receiptState}</code>
           </div>
-          {reason === null ? (
-            <pre>
-              <code>
-                {"const result = await handle.promise;\n// waiting for a close"}
-              </code>
-            </pre>
-          ) : (
-            <pre key={reason}>
+          {phase === "resolved" ? (
+            <pre key={selectedReason}>
               <code>
                 <span>{"{"}</span>
                 {"\n  reason: "}
                 <b>MagicModalHideReason.</b>
-                <mark>{reason}</mark>
-                {hasData && (
+                <mark>{selectedReason}</mark>
+                {result?.reason === MagicModalHideReason.INTENTIONAL_HIDE && (
                   <>
                     {",\n  data: "}
-                    <em>{"{ answer: 42 }"}</em>
+                    <em>{`{ answer: ${result.data.answer} }`}</em>
                   </>
                 )}
                 {"\n"}
                 <span>{"}"}</span>
               </code>
             </pre>
+          ) : (
+            <pre>
+              <code>
+                {visualPhase === "closing"
+                  ? "const result = await handle.promise;\n// waiting for the close animation"
+                  : "const result = await handle.promise;\n// waiting for a close"}
+              </code>
+            </pre>
           )}
           <small>
-            {reason === null
-              ? "Press an action to resolve the promise"
-              : triggerByReason[reason]}
+            {phase === "pending" &&
+              visualPhase === "open" &&
+              "Press one action to resolve the promise"}
+            {phase === "pending" &&
+              visualPhase === "closing" &&
+              "The promise resolves when the close animation finishes."}
+            {phase === "resolved" &&
+              selectedReason &&
+              triggerByReason[selectedReason]}
           </small>
         </div>
       </div>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,7 +11,7 @@
     "lint": "oxlint --report-unused-disable-directives",
     "start": "serve out",
     "test": "node --test test/*.test.mjs",
-    "typecheck": "fumadocs-mdx && next typegen && tsc --noEmit"
+    "typecheck": "fumadocs-mdx && next typegen && fumadocs-mdx && tsc --noEmit"
   },
   "dependencies": {
     "@fontsource-variable/instrument-sans": "5.3.0",


### PR DESCRIPTION
## What changed

- removed the release-history section that interrupted the main story
- replaced the fake upload timer with a real `magicModal.show()` and `update()` flow
- rebuilt the close-results lab around the package’s actual promise timing
- added a draggable swipe interaction, an exposed mobile backdrop, and a locked first-result state
- fixed phone proportions, the tablet example layout, scroll overlap, receipt clipping, contrast, and mobile bottom geometry

## Why

The first docs PR established the new site, but a few demos still looked or behaved like mockups. The close-results example also treated every dismissal as if the promise resolved after the animation, which is not how the package works. This pass makes the examples teach the real API and removes a section that did not help that explanation.

## Preview

https://pr-317.react-native-magic-modal-preview.pages.dev/

Source: `39b81ee5c06d9c857db1638595453dc37dff68e8`

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm format`
- `pnpm --filter @magic-modal/docs build`
- browser QA at 390×844, 768×900, and 1280×800
- real package stack test with two concurrent entries
- upload progress verified at an intermediate value, 100% pending, then resolved on close
- all five close results, real swipe, snap-back, reduced motion, reset, and first-result locking
- clean docs typecheck on Node 24 after regenerating the Fumadocs source
