### PR TITLE
fix(ci): ship the README in the npm tarball

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -16,18 +16,17 @@
       "persistent": true
     },
     "lint": {
-      "dependsOn": ["^topo", "^build"],
-      "outputs": ["node_modules/.cache/.lintcache"]
+      "dependsOn": ["^topo", "^build"]
     },
+    "format": {},
+    // Both of these rewrite the tree, so a cache hit has nothing to restore and
+    // replaying one skips oxlint and oxfmt.
     "lint:fix": {
-      "dependsOn": ["^topo", "^build"],
-      "outputs": ["node_modules/.cache/.lintcache"]
-    },
-    "format": {
-      "outputs": ["node_modules/.cache/.formatcache"]
+      "cache": false,
+      "dependsOn": ["^topo", "^build"]
     },
     "format:fix": {
-      "outputs": ["node_modules/.cache/.formatcache"]
+      "cache": false
     },
     "test": {
       "dependsOn": ["^topo"],
@@ -42,19 +41,17 @@
     "copy:readme": {
       "cache": false
     },
+    // packages/modal/README.md is gitignored and only exists once
+    // `copy:readme` generates it, so the publish has to depend on it.
+    // `^copy:readme` would ask for the task in this package's dependencies, and
+    // react-native-magic-modal has no workspace dependencies, so that resolves
+    // to nothing.
+    //
+    // Uncached because publishing is a one-shot side effect with nothing on
+    // disk for a hit to restore.
     "release": {
-      "dependsOn": ["^copy:readme"],
-      "outputs": ["node_modules/.cache/release.json"]
-    },
-    "docs": {
-      "dependsOn": ["^copy:readme"],
-      "outputs": ["docs/**", "node_modules/.cache/docs.json"]
-    },
-    "clean": {
-      "cache": false
-    },
-    "//#clean": {
-      "cache": false
+      "cache": false,
+      "dependsOn": ["copy:readme"]
     }
   }
 }


### PR DESCRIPTION
`release` now depends on `copy:readme`, so the npm tarball carries a README. `release`, `lint:fix` and `format:fix` stop being cached. The `outputs` keys and task definitions that never did anything are gone.

## Problem

`react-native-magic-modal` on npm has no README. The registry's `readme` field for the package is the literal string `ERROR: No README data found!`, and the 9.1.0 tarball is `dist/` plus `package.json`.

`packages/modal/README.md` is gitignored and generated by `copy:readme` (`shx cp ../../README.md ./README.md`). `turbo.json` was meant to run it before publishing:

```json
"release": { "dependsOn": ["^copy:readme"] }
```

The `^` prefix asks for the same task in this package's dependencies. `react-native-magic-modal` has no workspace dependencies, so it resolves to nothing and the script has never run in CI. `turbo run release --filter=react-native-magic-modal --dry` on `main`:

```
react-native-magic-modal#release
  Command                        = release-it --ci
  Dependencies                   =
```

and on this branch:

```
react-native-magic-modal#copy:readme
  Command                        = shx cp ../../README.md ./README.md
  Dependencies                   =
react-native-magic-modal#release
  Command                        = release-it --ci
  Dependencies                   = react-native-magic-modal#copy:readme
```

Every release job so far has reached `npm pack` with that file absent. Same state locally, in `packages/modal`:

```
npm notice Tarball Contents
npm notice 191B dist/dev-runtime.cjs
npm notice 191B dist/dev-runtime.js
npm notice 80B dist/index.cjs
npm notice 9.1kB dist/index.d.cts
npm notice 9.1kB dist/index.d.ts
npm notice 64B dist/index.js
npm notice 30.3kB dist/index.runtime.cjs
npm notice 28.7kB dist/index.runtime.js
npm notice 3.0kB package.json
npm notice total files: 9
```

Those nine paths are byte for byte the listing published as 9.1.0. After `turbo run copy:readme` the same command reports `9.2kB README.md` at the top and `total files: 10`.

`.release-it.js` already sets `git.requireCleanWorkingDir: false`, and the copied file is gitignored, so generating it inside the release job touches nothing else.

## Caching

`release`, `lint:fix` and `format:fix` get `cache: false`. Publishing is a one-shot side effect with nothing on disk to restore, and the same goes for the two tasks that rewrite the tree, where replaying a hit skips the tool. Two `format:fix` runs in a row against `main`'s config:

```
$ pnpm exec turbo run format:fix
@magic-modal/docs:format:fix: cache hit, replaying logs 5b4a162ba9aed0b3
@magic/kitchen-sink:format:fix: cache hit, replaying logs 1df73d134a5ec585
react-native-magic-modal:format:fix: cache hit, replaying logs 0fefbcbfacd7edf0
@magic-modal/docs:format:fix: $ oxfmt .
@magic-modal/docs:format:fix: Finished in 617ms on 67 files using 10 threads.
react-native-magic-modal:format:fix: $ oxfmt .
react-native-magic-modal:format:fix: Finished in 88ms on 31 files using 10 threads.
@magic/kitchen-sink:format:fix: $ oxfmt .
@magic/kitchen-sink:format:fix: Finished in 447ms on 28 files using 10 threads.
 Tasks:    3 successful, 3 total
Cached:    3 cached, 3 total
  Time:    66ms >>> FULL TURBO

$ pnpm exec turbo run format:fix
@magic/kitchen-sink:format:fix: cache hit, replaying logs 1df73d134a5ec585
@magic-modal/docs:format:fix: cache hit, replaying logs 5b4a162ba9aed0b3
@magic/kitchen-sink:format:fix: $ oxfmt .
@magic/kitchen-sink:format:fix: Finished in 447ms on 28 files using 10 threads.
@magic-modal/docs:format:fix: $ oxfmt .
@magic-modal/docs:format:fix: Finished in 617ms on 67 files using 10 threads.
react-native-magic-modal:format:fix: cache hit, replaying logs 0fefbcbfacd7edf0
react-native-magic-modal:format:fix: $ oxfmt .
react-native-magic-modal:format:fix: Finished in 88ms on 31 files using 10 threads.
 Tasks:    3 successful, 3 total
Cached:    3 cached, 3 total
  Time:    12ms >>> FULL TURBO
```

`617ms`, `88ms` and `447ms` repeat to the millisecond across both runs because they are replayed text. oxfmt never ran. On this branch, same two runs:

```
$ pnpm exec turbo run format:fix
@magic/kitchen-sink:format:fix: cache bypass, force executing e3fdf45f3cd55313
react-native-magic-modal:format:fix: cache bypass, force executing a4b25cc4ea190172
@magic-modal/docs:format:fix: cache bypass, force executing 55c56a6703f8e185
react-native-magic-modal:format:fix: $ oxfmt .
@magic-modal/docs:format:fix: $ oxfmt .
@magic/kitchen-sink:format:fix: $ oxfmt .
react-native-magic-modal:format:fix: Finished in 192ms on 31 files using 10 threads.
@magic/kitchen-sink:format:fix: Finished in 461ms on 28 files using 10 threads.
@magic-modal/docs:format:fix: Finished in 669ms on 67 files using 10 threads.
 Tasks:    3 successful, 3 total
Cached:    0 cached, 3 total
  Time:    1.232s

$ pnpm exec turbo run format:fix
@magic-modal/docs:format:fix: cache bypass, force executing 55c56a6703f8e185
@magic/kitchen-sink:format:fix: cache bypass, force executing e3fdf45f3cd55313
react-native-magic-modal:format:fix: cache bypass, force executing a4b25cc4ea190172
@magic/kitchen-sink:format:fix: $ oxfmt .
@magic-modal/docs:format:fix: $ oxfmt .
react-native-magic-modal:format:fix: $ oxfmt .
react-native-magic-modal:format:fix: Finished in 184ms on 31 files using 10 threads.
@magic/kitchen-sink:format:fix: Finished in 413ms on 28 files using 10 threads.
@magic-modal/docs:format:fix: Finished in 572ms on 67 files using 10 threads.
 Tasks:    3 successful, 3 total
Cached:    0 cached, 3 total
  Time:    1.251s
```

## Dead configuration

Seven `outputs` keys on `main`, and only `build`'s names a path anything writes. `lint`, `lint:fix`, `format` and `format:fix` pointed at `node_modules/.cache/.lintcache` and `.formatcache`, which oxlint and oxfmt don't create, `release` pointed at `node_modules/.cache/release.json`, and `docs` pointed at `docs/**` plus `node_modules/.cache/docs.json`. `turbo run lint format --force` piped through `grep -c WARNING`:

```
main:        6
this branch: 0
```

`docs`, `clean` and `//#clean` are gone. No package declares a `clean` script, and the root `docs` script runs two `pnpm --filter` builds rather than `turbo run docs`, so none of the three was reachable.

## Verification

`build`, `typecheck` and `format` pass with `--force`, so nothing replayed. `test` gives 39 jest tests across 5 suites in `packages/modal` plus 9 `node:test` assertions in `apps/docs`. `expo-doctor` is 19/19 in the kitchen sink. `changelog:check` passes, including its negative control. Lint checked by running `oxlint` directly in each of the three workspaces, exit 0 each, because CI reaches it through `pnpm run lint` and a turbo cache hit there replays the old log rather than linting. Full log: https://github.com/GSTJ/pr-assets-dump/tree/main/react-native-magic-modal/turbo-release-readme
