### PR TITLE
fix(docs): stop the footer column clipping between 701px and 812px

### DIFF
--- a/apps/docs/app/(home)/home.css
+++ b/apps/docs/app/(home)/home.css
@@ -4023,6 +4023,34 @@ body:has(.magic-home) {
     max-width: 360px;
     width: 100%;
   }
+
+  /* The four-column footer's tracks are 650px of hard minimums plus three
+     clamp(2rem, 5vw, 5rem) gaps, and they start at the 5vw left padding, so
+     their right edge sits at 650 + 0.2 * viewport. That is inside the viewport
+     only from 812.5px up. Under it the body clips the overflow instead of
+     scrolling, so the license line and the version were cut off on every width
+     down to 701px. Two columns here, the same shape the max-width: 700px block
+     below gives the footer. */
+  .mm-footer {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mm-footer-intro,
+  .mm-footer-meta {
+    grid-column: 1 / -1;
+  }
+
+  .mm-footer-meta {
+    border-top: 1px solid var(--mm-dark-line);
+    grid-auto-flow: column;
+    justify-content: space-between;
+    justify-items: start;
+    padding-top: 1.25rem;
+  }
+
+  .mm-footer-meta span {
+    text-align: left;
+  }
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
Collapses the footer to two columns between 701px and 860px, so the meta column stops running off the right edge.

## Problem

`MIT license` and `v9.1.0` are cut off on every width from 701px to 812px. iPad portrait, 768px, sits in that band. Live `main` at 768px:

![footer at 768px on main, MIT license clipped at the right edge](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/main/react-native-magic-modal/footer-tablet-clipping/footer-before-768.png)

`.mm-footer`'s base grid asks for four columns with hard minimums, `260 + 120 + 120 + 150 = 650px`, plus three gaps of `clamp(2rem, 5vw, 5rem)`, which is `5vw` for any viewport between 640px and 1600px. Padding is `5vw` per side, so the tracks start at `0.05w` and run `650 + 0.15w` wide, putting their right edge at `650 + 0.2w`. At 768px that predicts 803.6 and the measured edge is 803.56. It clears the viewport once `w > 812.5`, and the measured overhang crosses zero between 812px (`+0.38`) and 813px (`-0.44`).

The tracks overflow the footer's own content box until about 867px, they land inside the right padding from 812.5px up. Under that they land outside the viewport, and `body` clips rather than scrolls.

The two-column collapse that would have handled this starts at `max-width: 700px`.

Measured, `.mm-footer-meta`'s right edge minus `clientWidth`. Positive means clipped:

| width | main | this branch |
| --- | --- | --- |
| 420 | -27.19 | -27.19 |
| 700 | -27.19 | -27.19 |
| 701 | **+89.19** | -35.05 |
| 768 | **+35.56** | -38.39 |
| 800 | **+10.00** | -40.00 |
| 810 | **+2.00** | -40.50 |
| 811 | **+1.19** | -40.55 |
| 812 | **+0.38** | -40.59 |
| 813 | -0.44 | -40.64 |
| 860 | -38.00 | -43.00 |
| 861 | -38.81 | -38.81 |
| 900 | -45.02 | -45.02 |
| 1280 | -64.00 | -64.00 |

420px and 700px sit under the `max-width: 700px` block, where padding is `1.7rem` rather than `5vw`, which is why those two rows don't follow the formula above.

## Fix

The footer collapses to two columns inside the `701px` to `860px` block the example panel already uses, with the meta row spanning both and reading left-aligned, the same shape the `max-width: 700px` block gives it. 860px is the block's existing edge and sits above the 812.5px the clipping needs. 861px and up are byte-identical to `main`.

![footer at 768px on this branch, MIT license and v9.1.0 both inside the viewport](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/main/react-native-magic-modal/footer-tablet-clipping/footer-after-768.png)

## Verification

Built with `pnpm run build`, served from `apps/docs/out` under the export's basePath, driven in Chromium at the thirteen widths above, with `main` measured against the deployed site. `build`, `typecheck` and `format` pass with `--force`. `test` gives 39 jest tests across 5 suites in `packages/modal` plus 9 `node:test` assertions in `apps/docs`. `expo-doctor` is 19/19 in the kitchen sink. `changelog:check` passes, including its negative control. Lint checked by running `oxlint` directly in each of the three workspaces, because CI reaches it through `pnpm run lint` and a turbo cache hit there replays the old log rather than linting. Full numbers and log: https://github.com/GSTJ/pr-assets-dump/tree/main/react-native-magic-modal/footer-tablet-clipping
