### PR TITLE
feat(modal): awaitable show handle and lazy-mounted iOS overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@
 ## How it works
 
 `MagicModalPortal` owns a stack near the application root. Each `show()` call pushes one entry and
-returns its ID plus a `Promise<HideReturn<T>>`. The modal calls `hide(data)` through
+returns an awaitable handle: a `Promise<HideReturn<T>>` carrying that entry's `modalID`, `update`,
+and `hide`. The modal calls `hide(data)` through
 `useMagicModal<T>()`. The caller resumes with submitted data or the exact dismissal reason.
 
 ```tsx
 const result = await magicModal.show<ConfirmationResult>(ConfirmationModal, {
   accessibilityLabel: "Confirm publish",
-}).promise;
+});
 
 if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
   await publish(result.data);
@@ -39,6 +40,9 @@ if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
   recordCancellation(result.reason);
 }
 ```
+
+`const { promise, modalID, update } = magicModal.show(...)` still works; `promise` is a deprecated
+alias of the handle itself.
 
 Every stack entry keeps its own component, configuration, ID, and promise. A second `show()` call
 can open above the current modal without mixing their results.
@@ -140,7 +144,7 @@ function ConfirmationModal() {
 export async function confirmRelease() {
   const result = await magicModal.show<ConfirmationResult>(ConfirmationModal, {
     accessibilityLabel: "Publish this release",
-  }).promise;
+  });
 
   if (result.reason !== MagicModalHideReason.INTENTIONAL_HIDE) {
     return { confirmed: false, reason: result.reason };

--- a/apps/docs/content/docs/getting-started/first-modal.mdx
+++ b/apps/docs/content/docs/getting-started/first-modal.mdx
@@ -42,7 +42,7 @@ function ConfirmationModal() {
 export async function confirmDeletion() {
   const result = await magicModal.show<Confirmation>(ConfirmationModal, {
     accessibilityLabel: "Confirm project deletion",
-  }).promise;
+  });
 
   if (result.reason !== MagicModalHideReason.INTENTIONAL_HIDE) {
     return false;
@@ -51,6 +51,11 @@ export async function confirmDeletion() {
   return result.data.confirmed;
 }
 ```
+
+`show()` hands back a handle that is itself the promise, so awaiting it gives the result directly.
+The older `const { promise } = magicModal.show(...)` form still works; `promise` is an alias of the
+handle. Keep the handle when the calling code needs `modalID`, `update`, or `hide` while the modal
+stays open.
 
 The promise also resolves when the backdrop, swipe gesture, system-dismiss action, or `hideAll`
 closes the modal. System dismissal includes Android back, web Escape, and the native accessibility

--- a/apps/docs/content/docs/guides/native-overlays.mdx
+++ b/apps/docs/content/docs/guides/native-overlays.mdx
@@ -6,6 +6,11 @@ description: Control whether Magic Modal renders above native modal screens such
 On iOS, Magic Modal can use a full-window overlay so application modals stay above native screens.
 This is enabled by default.
 
+The overlay is a native window, so the portal only mounts it while the stack has something in it.
+An idle app has no extra window in its accessibility tree, which keeps screen readers and UI test
+selectors on the real screen. It stays mounted through the closing animation and unmounts once the
+last modal has finished animating out.
+
 Disable it before an interaction that should sit behind a native picker:
 
 ```tsx

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -10,7 +10,7 @@ other async flow.
 ```tsx
 const result = await magicModal.show<ConfirmationResult>(ConfirmationModal, {
   accessibilityLabel: "Confirm purchase",
-}).promise;
+});
 
 if (
   result.reason === MagicModalHideReason.INTENTIONAL_HIDE &&
@@ -19,6 +19,10 @@ if (
   completePurchase();
 }
 ```
+
+`show()` returns a handle that is itself the promise, carrying `modalID`, `update`, and `hide` for
+the entry it opened. The older `const { promise } = magicModal.show(...)` form still works:
+`promise` is an alias of the handle.
 
 ## Core model
 
@@ -48,7 +52,7 @@ if (
 ## The mental model
 
 1. [`MagicModalPortal`](/docs/reference/magic-modal-portal) owns the modal stack. Mount it once.
-2. [`magicModal.show`](/docs/reference/magic-modal) pushes one entry and returns its ID and promise.
+2. [`magicModal.show`](/docs/reference/magic-modal) pushes one entry and returns an awaitable handle.
 3. [`useMagicModal().hide`](/docs/reference/use-magic-modal) closes that entry with typed data.
 4. The promise resolves to [`HideReturn<T>`](/docs/reference/hide-results), including the close reason.
 

--- a/apps/docs/content/docs/reference/magic-modal.mdx
+++ b/apps/docs/content/docs/reference/magic-modal.mdx
@@ -12,28 +12,55 @@ description: Show, hide, and configure stack entries from application code.
 show<T>(
   component: React.FC,
   config?: Partial<ModalProps>,
-): {
-  promise: Promise<HideReturn<T>>;
+): ModalHandle<T>
+
+type ModalHandle<T> = Promise<HideReturn<T>> & {
   modalID: string;
-  update: (component: React.FC) => void;
-}
+  update: (next: React.FC) => void;
+  hide: (data?: T) => void;
+  /** @deprecated await the handle directly */
+  promise: Promise<HideReturn<T>>;
+};
 ```
 
-Pushes a modal to the top of the stack.
+Pushes a modal to the top of the stack. The returned handle _is_ the promise, so await it:
 
 ```tsx
-const { modalID, promise } = magicModal.show<Profile>(() => <ProfilePicker />, {
+const result = await magicModal.show<Profile>(() => <ProfilePicker />, {
   accessibilityLabel: "Choose a profile",
   backdropColor: "rgba(7, 6, 18, 0.72)",
   swipeDirection: "down",
 });
 ```
 
-| Return    | Purpose                                                |
-| --------- | ------------------------------------------------------ |
-| `promise` | Resolves once when this modal closes.                  |
-| `modalID` | Addresses this exact entry from outside its component. |
-| `update`  | Advanced API that replaces and remounts its content.   |
+Keep the handle instead when the caller needs to drive the modal while it is open:
+
+```tsx
+const handle = magicModal.show<Profile>(() => <ProfilePicker />);
+
+handle.update(() => <ProfilePicker step={2} />);
+handle.hide({ id: "cached" });
+```
+
+| Member    | Purpose                                                          |
+| --------- | ---------------------------------------------------------------- |
+| _awaited_ | Resolves once when this modal closes.                            |
+| `modalID` | Addresses this exact entry from outside its component.           |
+| `update`  | Advanced API that replaces and remounts its content.             |
+| `hide`    | Closes this entry with an intentional result.                    |
+| `promise` | Deprecated alias of the handle. Kept so old destructuring works. |
+
+`const { promise, modalID, update } = magicModal.show(...)` still works exactly as before, and
+`promise` is the same object as the handle.
+
+<Callout type="warn">
+  The controls hang off the promise, so anything that adopts the handle hands
+  back a plain promise without them. Returning it straight from an `async`
+  function is the case that bites: `const open = async () =>
+  magicModal.show(Modal)` gives the caller a promise with no `modalID`,
+  `update`, or `hide`. Return it from a non-async function, or await it where
+  you open it.
+</Callout>
 
 See [hide results](/docs/reference/hide-results) for promise narrowing. Read
 [replace open content](/docs/guides/updating-content) before using `update()`, since it remounts the

--- a/examples/kitchen-sink/src/app/index.tsx
+++ b/examples/kitchen-sink/src/app/index.tsx
@@ -41,8 +41,9 @@ const showModal = async () => {
     magicModal.hide("close timeout", { modalID: modalResponse.modalID });
   }, 2000);
 
+  // The handle is the promise, so awaiting it gives the hide result.
   // eslint-disable-next-line no-console
-  console.log("Modal closed with response:", await modalResponse.promise);
+  console.log("Modal closed with response:", await modalResponse);
 };
 
 type ModalResponse = {
@@ -64,6 +65,7 @@ const showReplacingModals = async () => {
     { modalID: modalResponse.modalID },
   );
 
+  // `.promise` still works here, and is the same object as the handle.
   const res = await modalResponse.promise;
 
   if (res.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
@@ -95,23 +97,23 @@ const showZoomInModal = () => {
 };
 
 const showUpdatingModal = async () => {
-  const { modalID, update } = magicModal.show(() => (
-    <ExampleModal body="Closing in 3..." />
-  ));
+  // The handle carries the controls for this entry, so nothing here needs the
+  // modal ID.
+  const modal = magicModal.show(() => <ExampleModal body="Closing in 3..." />);
 
   await wait(1000);
-  update(() => <ExampleModal body="Closing in 2..." />);
+  modal.update(() => <ExampleModal body="Closing in 2..." />);
 
   await wait(1000);
-  update(() => <ExampleModal body="Closing in 1..." />);
+  modal.update(() => <ExampleModal body="Closing in 1..." />);
 
   await wait(1000);
-  magicModal.hide(undefined, { modalID });
+  modal.hide();
 };
 
 const showNoFullWindowOverlayModal = async () => {
   magicModal.disableFullWindowOverlay();
-  await magicModal.show(() => <ExampleModal />).promise;
+  await magicModal.show(() => <ExampleModal />);
   magicModal.enableFullWindowOverlay();
 };
 

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
@@ -18,9 +18,14 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from "react";
 import { BackHandler, Platform, StyleSheet, View } from "react-native";
 
+import {
+  ANIMATION_DURATION_IN_MS,
+  OVERLAY_UNMOUNT_GRACE_IN_MS,
+} from "../../constants/animations";
 import { defaultConfig } from "../../constants/default-config";
 import { MagicModalHideReason } from "../../constants/types";
 import { magicModalRef } from "../../utils/magic-modal-handler";
@@ -87,6 +92,12 @@ export const createMagicModalPortal = (
     const [modals, setModals] = React.useState<ModalStackItem[]>([]);
     const [fullWindowOverlayEnabled, setFullWindowOverlayEnabled] =
       React.useState(true);
+    // Mounting the overlay permanently creates a native UIWindow that owns the
+    // accessibility tree even with an empty stack, so it is mounted on demand.
+    const [isOverlayMounted, setIsOverlayMounted] = React.useState(false);
+    // The exit timing of whatever is currently on the stack, kept so the
+    // unmount delay is still readable once the stack is empty.
+    const exitTimingRef = useRef(ANIMATION_DURATION_IN_MS);
 
     const disableFullWindowOverlay = useCallback(() => {
       setFullWindowOverlayEnabled(false);
@@ -184,6 +195,9 @@ export const createMagicModalPortal = (
           },
         } satisfies ModalStackItem;
 
+        // Batched with the stack update, so the overlay and the modal land in
+        // the same commit and the entering animation runs once, inside it.
+        setIsOverlayMounted(true);
         setModals((prevModals) => [...prevModals, newModal]);
 
         return createModalHandle<T>(hidePromise, {
@@ -202,6 +216,40 @@ export const createMagicModalPortal = (
       },
       [_hide, update],
     );
+
+    /**
+     * Keeps the overlay alive through the closing animation.
+     *
+     * A hidden entry leaves state immediately, but its Reanimated `exiting`
+     * animation is still playing. Unmounting the overlay right then tears down
+     * the native window mid-animation: the closing modal blinks, drops out of
+     * the top layer, and loses focus. So the unmount waits out the exit timing
+     * of whatever was on the stack.
+     *
+     * Anything that repopulates the stack, a `show` during the wait included,
+     * changes `modals` and cancels the pending unmount through the cleanup, so
+     * back-to-back modals never blink.
+     */
+    useEffect(() => {
+      if (modals.length > 0) {
+        exitTimingRef.current = Math.max(
+          ...modals.map((modal) => modal.config.animationOutTiming),
+        );
+        return;
+      }
+
+      if (!isOverlayMounted) {
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        setIsOverlayMounted(false);
+      }, exitTimingRef.current + OVERLAY_UNMOUNT_GRACE_IN_MS);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, [isOverlayMounted, modals]);
 
     useEffect(() => {
       if (Platform.OS === "web") {
@@ -278,12 +326,13 @@ export const createMagicModalPortal = (
     }, [modals]);
 
     const Overlay =
-      fullWindowOverlayEnabled && Platform.OS === "ios"
+      fullWindowOverlayEnabled && isOverlayMounted && Platform.OS === "ios"
         ? FullWindowOverlay
         : React.Fragment;
 
-    /* This needs to always be rendered, if we make it conditionally render based on ModalContent too,
-     the modal will have zIndex issues on react-navigation modals. */
+    /* The View below stays rendered whether or not there are modals: making it
+     conditional on ModalContent gives the modal zIndex issues on
+     react-navigation modals. Only the overlay wrapper comes and goes. */
     return (
       <Overlay>
         <View

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
@@ -2,8 +2,12 @@ import type {
   GlobalHideFunction,
   GlobalShowFunction,
   GlobalUpdateFunction,
+  HideReturn,
   ModalChildren,
+  ModalHandle,
   ModalProps,
+  ModalUpdateFunction,
+  NewConfigProps,
 } from "../../constants/types";
 
 import type { ElementType } from "react";
@@ -32,6 +36,28 @@ type ModalStackItem = {
   config: ModalProps;
   hideCallback: (value: unknown) => void;
   hideFunction: (props: unknown) => void;
+};
+
+/**
+ * Hangs the stack-entry controls off the modal's own promise, so callers can
+ * `await magicModal.show(...)` and still reach `modalID`, `update` and `hide`.
+ *
+ * `promise` points back at the handle: it is the deprecated alias that keeps
+ * `const { promise } = magicModal.show(...)` working.
+ */
+const createModalHandle = <T,>(
+  promise: Promise<HideReturn<T>>,
+  controls: {
+    modalID: string;
+    update: ModalUpdateFunction;
+    hide: (data?: T) => void;
+  },
+): ModalHandle<T> => {
+  // `Object.assign` returns the intersection, which is every part of
+  // `ModalHandle` except the self-referential `promise` assigned below.
+  const handle = Object.assign(promise, controls) as ModalHandle<T>;
+  handle.promise = handle;
+  return handle;
 };
 /**
  * @description A magic portal that should stay on the top of the app component hierarchy for the modal to be displayed.
@@ -131,14 +157,21 @@ export const createMagicModalPortal = (
     );
 
     const show = useCallback<GlobalShowFunction>(
-      (newComponent, newConfig) => {
+      // Written generic rather than relying on the contextual type, so `T`
+      // has a name inside and the handle can be built without casting it.
+      <T,>(
+        newComponent: ModalChildren,
+        newConfig?: NewConfigProps,
+      ): ModalHandle<T> => {
         const modalID = generatePseudoRandomID();
 
         let hideCallback: (value: unknown) => void = () => {
           // Empty function
         };
-        const hidePromise = new Promise((resolve) => {
-          hideCallback = resolve;
+        // The stack is payload-agnostic: it resolves whatever the hide caller
+        // passed, and `T` is what the caller declared that payload to be.
+        const hidePromise = new Promise<HideReturn<T>>((resolve) => {
+          hideCallback = resolve as (value: unknown) => void;
         });
 
         const newModal = {
@@ -153,15 +186,19 @@ export const createMagicModalPortal = (
 
         setModals((prevModals) => [...prevModals, newModal]);
 
-        return {
-          // This is already typed by the GlobalShowFunction type Generic
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          promise: hidePromise as any,
+        return createModalHandle<T>(hidePromise, {
           modalID,
-          update: (updatedComponent: ModalChildren) => {
+          update: (updatedComponent) => {
             update(updatedComponent, { modalID });
           },
-        } as const;
+          hide: (data) => {
+            // Same wiring the `useMagicModal` hook uses from inside the modal.
+            newModal.hideFunction({
+              reason: MagicModalHideReason.INTENTIONAL_HIDE,
+              data,
+            });
+          },
+        });
       },
       [_hide, update],
     );

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal.overlay.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal.overlay.test.tsx
@@ -1,0 +1,231 @@
+import type { ElementType, ReactNode } from "react";
+
+import React from "react";
+import { Platform, Text, View } from "react-native";
+
+import {
+  act,
+  render as rntlRender,
+  screen,
+} from "@testing-library/react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import {
+  ANIMATION_DURATION_IN_MS,
+  OVERLAY_UNMOUNT_GRACE_IN_MS,
+} from "../../constants/animations";
+import { magicModal } from "../../utils/magic-modal-handler";
+import { createMagicModalPortal } from "./magic-modal-portal-base";
+
+/**
+ * The iOS FullWindowOverlay is a native window. Left mounted with an empty
+ * stack it owns the accessibility tree for the whole app, which is why the
+ * portal only wraps itself in one while there is something to show.
+ *
+ * `createMagicModalPortal` takes the overlay as an argument, so these tests
+ * pass a stub with a testID instead of reaching for react-native-screens.
+ */
+const OVERLAY_TEST_ID = "full-window-overlay-stub";
+const includeHiddenElements = { includeHiddenElements: true } as const;
+
+const FullWindowOverlayStub: ElementType = ({
+  children,
+}: {
+  children?: ReactNode;
+}) => <View testID={OVERLAY_TEST_ID}>{children}</View>;
+
+const TestPortal = createMagicModalPortal(FullWindowOverlayStub);
+
+const ModalContent = () => <Text testID="overlay-modal">Taveira</Text>;
+
+const render = () =>
+  rntlRender(
+    <GestureHandlerRootView>
+      <TestPortal />
+    </GestureHandlerRootView>,
+  );
+
+const queryOverlay = () =>
+  screen.queryByTestId(OVERLAY_TEST_ID, includeHiddenElements);
+
+/** The window the portal waits out before it drops the native overlay. */
+const exitWindow = (animationOutTiming = ANIMATION_DURATION_IN_MS): number =>
+  animationOutTiming + OVERLAY_UNMOUNT_GRACE_IN_MS;
+
+const advanceBy = (ms: number) => {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+};
+
+// `Platform.OS` is typed as the literal of whichever platform the type
+// resolution picked, so it is widened here to swap in another one.
+const platformModule = Platform as unknown as { OS: string };
+
+describe("MagicModalPortal full window overlay", () => {
+  let platform: { replaceValue: (value: string) => void; restore: () => void };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    platform = jest.replaceProperty(platformModule, "OS", "ios");
+  });
+
+  afterEach(() => {
+    act(() => {
+      magicModal.hideAll();
+    });
+    // Drains the unmount the line above just scheduled, so it cannot fire
+    // outside `act` once the timers go back to real.
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    platform.restore();
+  });
+
+  it("leaves the overlay unmounted while the stack is empty", () => {
+    render();
+
+    expect(
+      screen.getByTestId("magic-modal-portal", includeHiddenElements),
+    ).toBeTruthy();
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("wraps the portal in the overlay once a modal is shown", () => {
+    render();
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    expect(queryOverlay()).toBeTruthy();
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+    // The stack lives inside the overlay, not beside it.
+    expect(
+      screen.getByTestId(OVERLAY_TEST_ID).findByProps({
+        testID: "magic-modal-portal",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the overlay mounted while the closing modal animates out", () => {
+    render();
+
+    let modalID = "";
+    act(() => {
+      modalID = magicModal.show(ModalContent).modalID;
+    });
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    // The entry is gone from state, the exit animation is not.
+    expect(screen.queryByTestId("overlay-modal")).toBeNull();
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(exitWindow() - 1);
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(1);
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("waits out a longer animationOutTiming before unmounting", () => {
+    render();
+
+    const animationOutTiming = 1000;
+    let modalID = "";
+
+    act(() => {
+      modalID = magicModal.show(ModalContent, { animationOutTiming }).modalID;
+    });
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    advanceBy(exitWindow() + 1);
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(exitWindow(animationOutTiming));
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("unmounts the overlay after hideAll clears the stack", () => {
+    render();
+
+    act(() => {
+      magicModal.show(ModalContent);
+      magicModal.show(ModalContent);
+    });
+
+    act(() => {
+      magicModal.hideAll();
+    });
+
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(exitWindow());
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("cancels the pending unmount when another modal opens during the exit window", () => {
+    render();
+
+    let modalID = "";
+    act(() => {
+      modalID = magicModal.show(ModalContent).modalID;
+    });
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    advanceBy(exitWindow() - 10);
+    expect(queryOverlay()).toBeTruthy();
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    // Past the deadline the first modal had scheduled: no blink between the two.
+    advanceBy(exitWindow());
+    expect(queryOverlay()).toBeTruthy();
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+  });
+
+  it("never mounts the overlay outside iOS", () => {
+    platform.replaceValue("android");
+    render();
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("keeps the overlay off while it is globally disabled", () => {
+    render();
+
+    act(() => {
+      magicModal.disableFullWindowOverlay();
+    });
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+    expect(queryOverlay()).toBeNull();
+
+    act(() => {
+      magicModal.enableFullWindowOverlay();
+    });
+
+    expect(queryOverlay()).toBeTruthy();
+  });
+});

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal.test.tsx
@@ -1,4 +1,4 @@
-import type { HookHideFunction } from "../../constants/types";
+import type { HookHideFunction, ModalHandle } from "../../constants/types";
 
 import React, { useEffect } from "react";
 import { BackHandler, Pressable, Text } from "react-native";
@@ -76,6 +76,110 @@ describe("MagicModalPortal", () => {
       data: { answer: 42 },
     });
     expect(screen.queryByTestId("second")).toBeNull();
+  });
+
+  it("resolves the handle itself when it is awaited", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<{ answer: number }> | undefined;
+
+    act(() => {
+      handle = magicModal.show<{ answer: number }>(() => (
+        <ModalContent testID="awaited" />
+      ));
+    });
+
+    await expect(screen.findByTestId("awaited")).resolves.toBeTruthy();
+
+    act(() => {
+      magicModal.hide({ answer: 42 }, { modalID: handle?.modalID });
+    });
+
+    await expect(handle).resolves.toStrictEqual({
+      reason: MagicModalHideReason.INTENTIONAL_HIDE,
+      data: { answer: 42 },
+    });
+    expect(screen.queryByTestId("awaited")).toBeNull();
+  });
+
+  it("keeps the legacy promise property as an alias of the handle", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<unknown> | undefined;
+    let promise: Promise<unknown> | undefined;
+    let modalID = "";
+    let update: (component: React.FC) => void = () => {};
+
+    act(() => {
+      handle = magicModal.show(() => <ModalContent testID="legacy" />);
+      // The destructuring every existing caller writes.
+      ({ promise, modalID, update } = handle);
+    });
+
+    expect(promise).toBe(handle);
+    expect(modalID).toBe(handle?.modalID);
+
+    act(() => {
+      update(() => <ModalContent testID="legacy-updated" />);
+    });
+
+    await expect(screen.findByTestId("legacy-updated")).resolves.toBeTruthy();
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    await expect(promise).resolves.toStrictEqual({
+      reason: MagicModalHideReason.INTENTIONAL_HIDE,
+      data: undefined,
+    });
+  });
+
+  it("swaps content through the handle's update", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<unknown> | undefined;
+
+    act(() => {
+      handle = magicModal.show(() => <ModalContent testID="handle-before" />);
+    });
+
+    await expect(screen.findByTestId("handle-before")).resolves.toBeTruthy();
+
+    act(() => {
+      handle?.update(() => <ModalContent testID="handle-after" />);
+    });
+
+    await expect(screen.findByTestId("handle-after")).resolves.toBeTruthy();
+    expect(screen.queryByTestId("handle-before")).toBeNull();
+
+    act(() => {
+      magicModal.hideAll();
+    });
+  });
+
+  it("closes the modal through the handle's hide", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<{ answer: number }> | undefined;
+
+    act(() => {
+      handle = magicModal.show<{ answer: number }>(() => (
+        <ModalContent testID="handle-hide" />
+      ));
+    });
+
+    await expect(screen.findByTestId("handle-hide")).resolves.toBeTruthy();
+
+    act(() => {
+      handle?.hide({ answer: 7 });
+    });
+
+    await expect(handle).resolves.toStrictEqual({
+      reason: MagicModalHideReason.INTENTIONAL_HIDE,
+      data: { answer: 7 },
+    });
+    expect(screen.queryByTestId("handle-hide")).toBeNull();
   });
 
   it("resolves an intentional hide from the modal-scoped hook", async () => {

--- a/packages/modal/src/constants/animations.ts
+++ b/packages/modal/src/constants/animations.ts
@@ -1,1 +1,13 @@
 export const ANIMATION_DURATION_IN_MS = 250;
+
+/**
+ * Extra time the iOS FullWindowOverlay stays mounted after the last modal
+ * leaves the stack.
+ *
+ * A stack entry is dropped from state as soon as it is hidden, while its
+ * Reanimated `exiting` animation keeps playing on the UI thread. Reanimated
+ * does not bridge a completion callback back to JS for layout animations, so
+ * the overlay unmount is timed off the entry's `animationOutTiming` plus this
+ * margin instead of being observed.
+ */
+export const OVERLAY_UNMOUNT_GRACE_IN_MS = 50;

--- a/packages/modal/src/constants/types.ts
+++ b/packages/modal/src/constants/types.ts
@@ -12,7 +12,7 @@ export type ModalChildren = React.FC;
 export type Direction = "up" | "down" | "left" | "right";
 
 /**
- * The discriminated result resolved by `magicModal.show<T>().promise`.
+ * The discriminated result resolved by `magicModal.show<T>()`.
  * `data` exists only when the modal was intentionally hidden.
  */
 export type HideReturn<T> =
@@ -154,11 +154,53 @@ export enum MagicModalHideReason {
   GLOBAL_HIDE_ALL = "GLOBAL_HIDE_ALL",
 }
 
+/**
+ * What `magicModal.show<T>()` hands back: the modal's result promise, with the
+ * controls for that stack entry hanging off it.
+ *
+ * Await it directly to get the {@link HideReturn}, or keep it around to drive
+ * the modal while it is open.
+ *
+ * ```tsx
+ * const handle = magicModal.show<Confirmation>(ConfirmationModal);
+ * handle.update(() => <ConfirmationModal step={2} />);
+ * const result = await handle;
+ * ```
+ *
+ * The controls live on the promise object itself, so anything that adopts the
+ * handle hands back a plain promise without them. Returning it from an `async`
+ * function is the common case:
+ *
+ * ```tsx
+ * // `modalID`, `update` and `hide` are gone from what the caller receives.
+ * const open = async () => magicModal.show(ConfirmationModal);
+ * ```
+ *
+ * Return the handle from a non-async function, or await it where you open it.
+ */
+export type ModalHandle<T> = Promise<HideReturn<T>> & {
+  /** Identifies this stack entry for `magicModal.hide` and `magicModal.update`. */
+  modalID: string;
+
+  /** Swaps the content of this modal while it stays open. */
+  update: (next: ModalChildren) => void;
+
+  /**
+   * Closes this modal from outside it, resolving the handle with
+   * {@link MagicModalHideReason.INTENTIONAL_HIDE} and `data`. Inside modal
+   * content, prefer `hide` from `useMagicModal`.
+   */
+  hide: (data?: T) => void;
+
+  /**
+   * @deprecated await the handle directly. Kept as an alias of the handle
+   * itself so existing `const { promise } = magicModal.show(...)` code keeps
+   * working.
+   */
+  promise: Promise<HideReturn<T>>;
+};
+
 export type GlobalShowFunction = <T>(
   newComponent: ModalChildren,
   newConfig?: NewConfigProps,
-) => {
-  promise: Promise<HideReturn<T>>;
-  modalID: string;
-  update: ModalUpdateFunction;
-};
+) => ModalHandle<T>;

--- a/packages/modal/src/index.react-native.ts
+++ b/packages/modal/src/index.react-native.ts
@@ -4,6 +4,7 @@ export {
   type HideReturn,
   type NewConfigProps,
   type ModalChildren,
+  type ModalHandle,
   type Direction,
   type ModalProps,
 } from "./constants/types";

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -4,6 +4,7 @@ export {
   type HideReturn,
   type NewConfigProps,
   type ModalChildren,
+  type ModalHandle,
   type Direction,
   type ModalProps,
 } from "./constants/types";

--- a/packages/modal/src/utils/magic-modal-handler.ts
+++ b/packages/modal/src/utils/magic-modal-handler.ts
@@ -9,9 +9,11 @@ import type {
 import React from "react";
 
 import {
-  // HideReturn is used in JS Doc
+  // HideReturn and ModalHandle are used in JS Doc
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   HideReturn,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ModalHandle,
 } from "../constants/types";
 
 export const magicModalRef = React.createRef<IModal>();
@@ -73,9 +75,7 @@ export type IModal = {
  *   );
  * };
  *
- * const result = await magicModal.show<{ message: string }>(
- *   ExampleModal,
- * ).promise;
+ * const result = await magicModal.show<{ message: string }>(ExampleModal);
  *
  * if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
  *   console.log(result.data.message);
@@ -87,7 +87,15 @@ export const magicModal = {
    * @description Pushes a modal to the Stack, it will be displayed on top of the others.
    * @param newComponent Receives a function that returns a modal component.
    * @param newConfig Receives {@link NewConfigProps} to override the default configs.
-   * @returns `promise`, which resolves with the {@link hide} props when the Modal is closed (if it were closed automatically, without the manual use of {@link hide}, the return would be one of {@link HideReturn}), the `modalID`, and an `update` function that swaps the modal's content while it stays open.
+   * @returns A {@link ModalHandle}: the promise that resolves with the {@link hide} props when the
+   * Modal is closed (if it were closed automatically, without the manual use of {@link hide}, the
+   * return would be one of {@link HideReturn}), carrying `modalID`, an `update` function that swaps
+   * the modal's content while it stays open, a `hide` function that closes this entry, and a
+   * deprecated `promise` alias of the handle itself.
+   * @example
+   * ```js
+   * const result = await magicModal.show(() => <ExampleModal />);
+   * ```
    * @example
    * ```js
    * const { update } = magicModal.show(() => <ExampleModal step={1} />);
@@ -96,6 +104,10 @@ export const magicModal = {
    * Prefer keeping state inside the modal component when you can. `update` is for data that
    * lives outside of it and can't reach in. The content is a new component, so it mounts from
    * scratch: anything the old one held in `useState` is gone.
+   *
+   * The controls hang off the promise, so awaiting the handle strips them. Returning it from an
+   * `async` function gives the caller a plain promise: return it from a normal function, or await
+   * it where the modal is opened.
    */
   show,
   /**
@@ -116,7 +128,7 @@ export const magicModal = {
    * @example
    * ```js
    * magicModal.disableFullWindowOverlay();
-   * await magicModal.show(() => <ExampleModal />).promise;
+   * await magicModal.show(() => <ExampleModal />);
    * magicModal.enableFullWindowOverlay();
    * ```
    * @platform ios
@@ -127,7 +139,7 @@ export const magicModal = {
    * @example
    * ```js
    * magicModal.disableFullWindowOverlay();
-   * await magicModal.show(() => <ExampleModal />).promise;
+   * await magicModal.show(() => <ExampleModal />);
    * magicModal.enableFullWindowOverlay();
    * ```
    * @platform ios


### PR DESCRIPTION
📝 **DESCRIPTION:**

DX changes aimed at the next minor:

1. `magicModal.show()` now returns an awaitable `ModalHandle<T>`: the result promise itself, with `modalID`, `update`, and `hide` attached. `await magicModal.show(...)` replaces `await magicModal.show(...).promise`. Existing destructuring keeps working; `promise` is now a deprecated alias of the handle. JSDoc and docs warn that returning the handle from an `async` function collapses it to a plain promise.

2. The iOS `FullWindowOverlay` now mounts only while modals are on screen. It used to mount permanently, and the native UIWindow it creates owns the accessibility tree even with no modal open, which breaks a11y selectors in e2e tools like maestro. The unmount waits out the longest `animationOutTiming` on the stack plus a 50ms margin, and a `show()` during that window cancels the pending unmount. Exit animations finish inside the overlay and back-to-back modals never lose it in between.

🖼 **PRINTS & GIFS:**

No visual changes intended.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

Two commits, both reworking the same portal internals (`magic-modal-portal-base.tsx`). Splitting them into separate PRs would chain textual conflicts through that file for no review benefit; each commit is self-contained and passes the full suite on its own.

##### Awesome tests or e2e (avoid `shallow` rendering)

12 new tests: 4 for the handle (awaiting it, legacy `.promise` destructuring, `update`, `hide(data)` resolving with `INTENTIONAL_HIDE`) and 8 for the overlay lifecycle (mount on show, still mounted right after hide, unmounted after the exit window, custom `animationOutTiming` respected, show-during-grace cancelling the unmount, `hideAll`, android, `disableFullWindowOverlay`). 63 tests passing overall. Gating the overlay on `modals.length > 0` alone fails 3 of the 8 overlay tests. The suite uses fake timers with a stub overlay component and doesn't depend on react-native-screens.
