### PR TITLE
feat(modal): return an awaitable handle from magicModal.show

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@
 ## How it works
 
 `MagicModalPortal` owns a stack near the application root. Each `show()` call pushes one entry and
-returns its ID plus a `Promise<HideReturn<T>>`. The modal calls `hide(data)` through
+returns an awaitable handle: a `Promise<HideReturn<T>>` carrying that entry's `modalID`, `update`,
+and `hide`. The modal calls `hide(data)` through
 `useMagicModal<T>()`. The caller resumes with submitted data or the exact dismissal reason.
 
 ```tsx
 const result = await magicModal.show<ConfirmationResult>(ConfirmationModal, {
   accessibilityLabel: "Confirm publish",
-}).promise;
+});
 
 if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
   await publish(result.data);
@@ -39,6 +40,9 @@ if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
   recordCancellation(result.reason);
 }
 ```
+
+`const { promise, modalID, update } = magicModal.show(...)` still works; `promise` is a deprecated
+alias of the handle itself.
 
 Every stack entry keeps its own component, configuration, ID, and promise. A second `show()` call
 can open above the current modal without mixing their results.
@@ -140,7 +144,7 @@ function ConfirmationModal() {
 export async function confirmRelease() {
   const result = await magicModal.show<ConfirmationResult>(ConfirmationModal, {
     accessibilityLabel: "Publish this release",
-  }).promise;
+  });
 
   if (result.reason !== MagicModalHideReason.INTENTIONAL_HIDE) {
     return { confirmed: false, reason: result.reason };

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -309,24 +309,24 @@ export default function HomePage() {
             What <code>magicModal.show()</code> returns
           </h2>
           <p>
-            Await the typed close result or target this stack entry by ID. The
-            advanced <code>update()</code> API replaces progress controlled
-            outside the modal.
+            The returned handle is itself the promise, so await it directly, or
+            target this stack entry by ID. The advanced <code>update()</code>{" "}
+            API replaces progress controlled outside the modal.
           </p>
         </div>
 
         <div className="mm-show-object" data-reveal>
-          <pre aria-label="The object returned by magicModal.show">
+          <pre aria-label="The handle returned by magicModal.show">
             <code>
-              <span>{"{"}</span>
-              {"\n  "}
-              <b>promise</b>
-              {": Promise<HideReturn<T>>;"}
+              <span>{"Promise<HideReturn<T>> & {"}</span>
               {"\n  "}
               <b>modalID</b>: string;
               {"\n  "}
               <b>update</b>
               {": (next: React.FC) => void;"}
+              {"\n  "}
+              <b>hide</b>
+              {": (data?: T) => void;"}
               {"\n"}
               <span>{"}"}</span>
             </code>
@@ -337,7 +337,7 @@ export default function HomePage() {
         <dl className="mm-show-ledger">
           <div data-reveal>
             <dt>
-              <code>promise</code>
+              <code>await handle</code>
               <span>01</span>
             </dt>
             <dd>Resolves when this entry closes.</dd>

--- a/apps/docs/components/live-package-demo.tsx
+++ b/apps/docs/components/live-package-demo.tsx
@@ -352,7 +352,7 @@ export const LivePackageDemo = () => {
         [{ ...entry, result: "PENDING" }, ...current].slice(0, 6),
       );
 
-      void handle.promise.then((result) => {
+      void handle.then((result) => {
         setActiveEntries((current) =>
           current.filter(({ id }) => id !== handle.modalID),
         );
@@ -379,7 +379,7 @@ export const LivePackageDemo = () => {
       modalConfig,
     );
 
-    await notification.promise;
+    await notification;
   }, [showTracked]);
 
   const runRatingFlow = useCallback(
@@ -405,7 +405,7 @@ export const LivePackageDemo = () => {
         await openNotification();
       }
 
-      const ratingResult = await rating.promise;
+      const ratingResult = await rating;
 
       if (ratingResult.reason !== MagicModalHideReason.INTENTIONAL_HIDE) {
         record({
@@ -425,7 +425,7 @@ export const LivePackageDemo = () => {
           FeedbackPrompt,
           modalConfig,
         );
-        const feedbackResult = await feedback.promise;
+        const feedbackResult = await feedback;
 
         detail =
           feedbackResult.reason === MagicModalHideReason.INTENTIONAL_HIDE
@@ -437,7 +437,7 @@ export const LivePackageDemo = () => {
           StorePrompt,
           modalConfig,
         );
-        const storeResult = await store.promise;
+        const storeResult = await store;
 
         detail =
           storeResult.reason === MagicModalHideReason.INTENTIONAL_HIDE &&
@@ -451,7 +451,7 @@ export const LivePackageDemo = () => {
         createThanksPrompt(detail),
         modalConfig,
       );
-      await thanks.promise;
+      await thanks;
       setRatingRunning(false);
     },
     [openNotification, ratingRunning, record, showTracked, updateRunning],
@@ -475,7 +475,7 @@ export const LivePackageDemo = () => {
     );
     let resolved = false;
 
-    void handle.promise.then(() => {
+    void handle.then(() => {
       resolved = true;
     });
 
@@ -504,7 +504,7 @@ export const LivePackageDemo = () => {
       Promise.resolve(),
     );
 
-    await handle.promise;
+    await handle;
     setUpdateRunning(false);
   }, [ratingRunning, record, showTracked, updateRunning]);
 
@@ -638,7 +638,7 @@ export const LivePackageDemo = () => {
             <pre>
               <code>
                 <span>const</span> result = <span>await</span> <b>magicModal</b>
-                {"\n  "}.show(RatingPrompt){"\n  "}.promise
+                {"\n  "}.show(RatingPrompt)
               </code>
             </pre>
             <footer>

--- a/apps/docs/components/origin-flow.tsx
+++ b/apps/docs/components/origin-flow.tsx
@@ -389,7 +389,7 @@ export const OriginFlow = () => {
               <b>const</b> rating = <b>await</b> magicModal
               {"\n"}
               <i />
-              {"  "}.show&lt;RatingAnswer&gt;(RatingModal).promise;
+              {"  "}.show&lt;RatingAnswer&gt;(RatingModal);
             </span>
             <span
               className={activeCodeClass(activeIndex, 1)}
@@ -419,7 +419,7 @@ export const OriginFlow = () => {
               {"    "}? FeedbackModal : StoreReviewModal
               {"\n"}
               <i />
-              ).promise;
+              );
             </span>
             <span
               className={activeCodeClass(activeIndex, 3)}
@@ -429,7 +429,7 @@ export const OriginFlow = () => {
               <b>await</b> magicModal
               {"\n"}
               <i />
-              {"  "}.show(ThanksModal).promise;
+              {"  "}.show(ThanksModal);
             </span>
             <span
               className={activeCodeClass(activeIndex, 4)}

--- a/apps/docs/components/practical-examples.tsx
+++ b/apps/docs/components/practical-examples.tsx
@@ -52,8 +52,7 @@ function DeletePostModal() {
 const result = await magicModal
   .show<Confirmation>(() => (
     <DeletePostModal />
-  ))
-  .promise;
+  ));
 
 if (
   result.reason === INTENTIONAL_HIDE &&
@@ -72,15 +71,13 @@ const examples: Example[] = [
   confirmExample,
   {
     code: `const account = await magicModal
-  .show<Account>(() => <AccountPicker />)
-  .promise;
+  .show<Account>(() => <AccountPicker />);
 
 if (account.reason === INTENTIONAL_HIDE) {
   await magicModal
     .show(() => (
       <AccountDetails account={account.data} />
-    ))
-    .promise;
+    ));
 }`,
     file: "account-flow.tsx",
     id: "follow-up",
@@ -89,17 +86,17 @@ if (account.reason === INTENTIONAL_HIDE) {
     type: "follow-up",
   },
   {
-    code: `const { update, promise } = magicModal.show(
+    code: `const handle = magicModal.show(
   () => <UploadModal progress={0} />
 );
 
 upload.onProgress((progress) => {
-  update(() => (
+  handle.update(() => (
     <UploadModal progress={progress} />
   ));
 });
 
-await promise;`,
+await handle;`,
     file: "upload.tsx",
     id: "update",
     label: "Advanced content replacement",

--- a/apps/docs/components/result-lab.tsx
+++ b/apps/docs/components/result-lab.tsx
@@ -63,9 +63,8 @@ const createResult = (reason: CloseReason): HideReturn<Answer> =>
     : { reason };
 
 const pendingCode = {
-  closing:
-    "const result = await handle.promise;\n// waiting for the close animation",
-  open: "const result = await handle.promise;\n// waiting for a close",
+  closing: "const result = await handle;\n// waiting for the close animation",
+  open: "const result = await handle;\n// waiting for a close",
 } as const;
 
 const formatResultCode = (result: HideReturn<Answer>) => {

--- a/apps/docs/content/docs/getting-started/first-modal.mdx
+++ b/apps/docs/content/docs/getting-started/first-modal.mdx
@@ -42,7 +42,7 @@ function ConfirmationModal() {
 export async function confirmDeletion() {
   const result = await magicModal.show<Confirmation>(ConfirmationModal, {
     accessibilityLabel: "Confirm project deletion",
-  }).promise;
+  });
 
   if (result.reason !== MagicModalHideReason.INTENTIONAL_HIDE) {
     return false;
@@ -51,6 +51,11 @@ export async function confirmDeletion() {
   return result.data.confirmed;
 }
 ```
+
+`show()` hands back a handle that is itself the promise, so awaiting it gives the result directly.
+The older `const { promise } = magicModal.show(...)` form still works; `promise` is an alias of the
+handle. Keep the handle when the calling code needs `modalID`, `update`, or `hide` while the modal
+stays open.
 
 The promise also resolves when the backdrop, swipe gesture, system-dismiss action, or `hideAll`
 closes the modal. System dismissal includes Android back, web Escape, and the native accessibility

--- a/apps/docs/content/docs/guides/accessibility.mdx
+++ b/apps/docs/content/docs/guides/accessibility.mdx
@@ -13,7 +13,7 @@ Pass a localized `accessibilityLabel` with each modal:
 const result = await magicModal.show<ConfirmationResult>(ConfirmationModal, {
   accessibilityLabel: "Confirm account deletion",
   swipeDirection: undefined,
-}).promise;
+});
 ```
 
 The label names the dialog for assistive technology. Keep a matching visible heading inside the
@@ -108,7 +108,7 @@ Handle every close path in the caller:
 ```tsx
 const result = await magicModal.show<FormResult>(FormModal, {
   accessibilityLabel: "Create profile",
-}).promise;
+});
 
 switch (result.reason) {
   case MagicModalHideReason.INTENTIONAL_HIDE:

--- a/apps/docs/content/docs/guides/modal-flows.mdx
+++ b/apps/docs/content/docs/guides/modal-flows.mdx
@@ -10,7 +10,7 @@ type Confirmation = { confirmed: boolean };
 
 const confirmation = await magicModal.show<Confirmation>(ConfirmationModal, {
   accessibilityLabel: "Confirm changes",
-}).promise;
+});
 
 if (
   confirmation.reason !== MagicModalHideReason.INTENTIONAL_HIDE ||
@@ -23,7 +23,7 @@ const response = await saveChanges();
 
 await magicModal.show(() => <ResultModal success={response.ok} />, {
   accessibilityLabel: response.ok ? "Changes saved" : "Save failed",
-}).promise;
+});
 ```
 
 ## Cancellation is part of the result
@@ -50,12 +50,12 @@ what to do with the original:
 ```tsx
 const account = await magicModal.show<Account>(AccountPicker, {
   accessibilityLabel: "Choose an account",
-}).promise;
+});
 
 if (account.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
   await magicModal.show(() => <AccountDetails account={account.data} />, {
     accessibilityLabel: "Account details",
-  }).promise;
+  });
 }
 ```
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -10,7 +10,7 @@ other async flow.
 ```tsx
 const result = await magicModal.show<ConfirmationResult>(ConfirmationModal, {
   accessibilityLabel: "Confirm purchase",
-}).promise;
+});
 
 if (
   result.reason === MagicModalHideReason.INTENTIONAL_HIDE &&
@@ -19,6 +19,10 @@ if (
   completePurchase();
 }
 ```
+
+`show()` returns a handle that is itself the promise, carrying `modalID`, `update`, and `hide` for
+the entry it opened. The older `const { promise } = magicModal.show(...)` form still works:
+`promise` is an alias of the handle.
 
 ## Core model
 
@@ -48,7 +52,7 @@ if (
 ## The mental model
 
 1. [`MagicModalPortal`](/docs/reference/magic-modal-portal) owns the modal stack. Mount it once.
-2. [`magicModal.show`](/docs/reference/magic-modal) pushes one entry and returns its ID and promise.
+2. [`magicModal.show`](/docs/reference/magic-modal) pushes one entry and returns an awaitable handle.
 3. [`useMagicModal().hide`](/docs/reference/use-magic-modal) closes that entry with typed data.
 4. The promise resolves to [`HideReturn<T>`](/docs/reference/hide-results), including the close reason.
 

--- a/apps/docs/content/docs/platforms/expo.mdx
+++ b/apps/docs/content/docs/platforms/expo.mdx
@@ -200,7 +200,7 @@ export async function askForRating() {
   const result = await magicModal.show<RatingResult>(RatingModal, {
     accessibilityLabel: "Rate your experience",
     swipeDirection: "down",
-  }).promise;
+  });
 
   if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
     return result.data.rating;

--- a/apps/docs/content/docs/platforms/ios-android.mdx
+++ b/apps/docs/content/docs/platforms/ios-android.mdx
@@ -56,7 +56,7 @@ The active modal consumes the Android back action and closes by default. Handle 
 the caller:
 
 ```tsx
-const result = await magicModal.show<CheckoutResult>(CheckoutModal).promise;
+const result = await magicModal.show<CheckoutResult>(CheckoutModal);
 
 switch (result.reason) {
   case MagicModalHideReason.INTENTIONAL_HIDE:

--- a/apps/docs/content/docs/platforms/nextjs.mdx
+++ b/apps/docs/content/docs/platforms/nextjs.mdx
@@ -186,7 +186,7 @@ export function ConfirmationButton() {
       swipeDirection: undefined,
     });
 
-    setStatus(describeResult(await entry.promise));
+    setStatus(describeResult(await entry));
   }
 
   return (

--- a/apps/docs/content/docs/reference/hide-results.mdx
+++ b/apps/docs/content/docs/reference/hide-results.mdx
@@ -3,7 +3,7 @@ title: Hide results
 description: Narrow the close reason to safely distinguish submitted data from cancellation.
 ---
 
-Every `show<T>().promise` resolves to `HideReturn<T>`:
+Every `show<T>()` resolves to `HideReturn<T>`:
 
 ```ts
 type HideReturn<T> =
@@ -25,7 +25,7 @@ Check the reason before reading `data`:
 ```tsx
 const result = await magicModal.show<FormValues>(FormModal, {
   accessibilityLabel: "Edit profile",
-}).promise;
+});
 
 if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
   await save(result.data);

--- a/apps/docs/content/docs/reference/magic-modal.mdx
+++ b/apps/docs/content/docs/reference/magic-modal.mdx
@@ -12,28 +12,55 @@ description: Show, hide, and configure stack entries from application code.
 show<T>(
   component: React.FC,
   config?: Partial<ModalProps>,
-): {
-  promise: Promise<HideReturn<T>>;
+): ModalHandle<T>
+
+type ModalHandle<T> = Promise<HideReturn<T>> & {
   modalID: string;
-  update: (component: React.FC) => void;
-}
+  update: (next: React.FC) => void;
+  hide: (data?: T) => void;
+  /** @deprecated await the handle directly */
+  promise: Promise<HideReturn<T>>;
+};
 ```
 
-Pushes a modal to the top of the stack.
+Pushes a modal to the top of the stack. The returned handle _is_ the promise, so await it:
 
 ```tsx
-const { modalID, promise } = magicModal.show<Profile>(() => <ProfilePicker />, {
+const result = await magicModal.show<Profile>(() => <ProfilePicker />, {
   accessibilityLabel: "Choose a profile",
   backdropColor: "rgba(7, 6, 18, 0.72)",
   swipeDirection: "down",
 });
 ```
 
-| Return    | Purpose                                                |
-| --------- | ------------------------------------------------------ |
-| `promise` | Resolves once when this modal closes.                  |
-| `modalID` | Addresses this exact entry from outside its component. |
-| `update`  | Advanced API that replaces and remounts its content.   |
+Keep the handle instead when the caller needs to drive the modal while it is open:
+
+```tsx
+const handle = magicModal.show<Profile>(() => <ProfilePicker />);
+
+handle.update(() => <ProfilePicker step={2} />);
+handle.hide({ id: "cached" });
+```
+
+| Member    | Purpose                                                          |
+| --------- | ---------------------------------------------------------------- |
+| _awaited_ | Resolves once when this modal closes.                            |
+| `modalID` | Addresses this exact entry from outside its component.           |
+| `update`  | Advanced API that replaces and remounts its content.             |
+| `hide`    | Closes this entry with an intentional result.                    |
+| `promise` | Deprecated alias of the handle. Kept so old destructuring works. |
+
+`const { promise, modalID, update } = magicModal.show(...)` still works exactly as before, and
+`promise` is the same object as the handle.
+
+<Callout type="warn">
+  The controls hang off the promise, so anything that adopts the handle hands
+  back a plain promise without them. Returning it straight from an `async`
+  function is the case that bites: `const open = async () =>
+  magicModal.show(Modal)` gives the caller a promise with no `modalID`,
+  `update`, or `hide`. Return it from a non-async function, or await it where
+  you open it.
+</Callout>
 
 See [hide results](/docs/reference/hide-results) for promise narrowing. Read
 [replace open content](/docs/guides/updating-content) before using `update()`, since it remounts the

--- a/apps/docs/content/docs/reference/use-magic-modal.mdx
+++ b/apps/docs/content/docs/reference/use-magic-modal.mdx
@@ -59,7 +59,7 @@ function ConfirmationModal() {
 export async function requestPublishApproval() {
   const result = await magicModal.show<Confirmation>(ConfirmationModal, {
     accessibilityLabel: "Confirm release publication",
-  }).promise;
+  });
 
   if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
     return result.data.approved;
@@ -78,12 +78,12 @@ reason and no `data`. Use `try`/`catch` for errors from the async work that foll
 
 ## Hook or imperative API
 
-| Situation                                               | API                                     |
-| ------------------------------------------------------- | --------------------------------------- |
-| The current modal closes itself                         | `useMagicModal<T>().hide(data)`         |
-| Application code opens a modal and waits for its result | `magicModal.show<T>(component).promise` |
-| Code outside the modal closes one known entry           | `magicModal.hide(data, { modalID })`    |
-| A logout or reset boundary clears the stack             | `magicModal.hideAll()`                  |
+| Situation                                               | API                                   |
+| ------------------------------------------------------- | ------------------------------------- |
+| The current modal closes itself                         | `useMagicModal<T>().hide(data)`       |
+| Application code opens a modal and waits for its result | `await magicModal.show<T>(component)` |
+| Code outside the modal closes one known entry           | `magicModal.hide(data, { modalID })`  |
+| A logout or reset boundary clears the stack             | `magicModal.hideAll()`                |
 
 For a modal that returns no data:
 

--- a/examples/kitchen-sink/src/app/index.tsx
+++ b/examples/kitchen-sink/src/app/index.tsx
@@ -41,8 +41,9 @@ const showModal = async () => {
     magicModal.hide("close timeout", { modalID: modalResponse.modalID });
   }, 2000);
 
+  // The handle is the promise, so awaiting it gives the hide result.
   // eslint-disable-next-line no-console
-  console.log("Modal closed with response:", await modalResponse.promise);
+  console.log("Modal closed with response:", await modalResponse);
 };
 
 type ModalResponse = {
@@ -64,6 +65,7 @@ const showReplacingModals = async () => {
     { modalID: modalResponse.modalID },
   );
 
+  // `.promise` still works here, and is the same object as the handle.
   const res = await modalResponse.promise;
 
   if (res.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
@@ -95,23 +97,23 @@ const showZoomInModal = () => {
 };
 
 const showUpdatingModal = async () => {
-  const { modalID, update } = magicModal.show(() => (
-    <ExampleModal body="Closing in 3..." />
-  ));
+  // The handle carries the controls for this entry, so nothing here needs the
+  // modal ID.
+  const modal = magicModal.show(() => <ExampleModal body="Closing in 3..." />);
 
   await wait(1000);
-  update(() => <ExampleModal body="Closing in 2..." />);
+  modal.update(() => <ExampleModal body="Closing in 2..." />);
 
   await wait(1000);
-  update(() => <ExampleModal body="Closing in 1..." />);
+  modal.update(() => <ExampleModal body="Closing in 1..." />);
 
   await wait(1000);
-  magicModal.hide(undefined, { modalID });
+  modal.hide();
 };
 
 const showNoFullWindowOverlayModal = async () => {
   magicModal.disableFullWindowOverlay();
-  await magicModal.show(() => <ExampleModal />).promise;
+  await magicModal.show(() => <ExampleModal />);
   magicModal.enableFullWindowOverlay();
 };
 

--- a/examples/kitchen-sink/src/app/swipe.tsx
+++ b/examples/kitchen-sink/src/app/swipe.tsx
@@ -36,7 +36,7 @@ const SwipeScreen = () => {
 
     const result = await magicModal.show(() => <ExampleModal />, {
       swipeDirection,
-    }).promise;
+    });
 
     setReasons((previous) => ({
       ...previous,

--- a/examples/kitchen-sink/src/components/toast.tsx
+++ b/examples/kitchen-sink/src/components/toast.tsx
@@ -44,7 +44,7 @@ export const showToast = async () => {
     style: {
       justifyContent: "flex-start",
     },
-  }).promise;
+  });
 
   // eslint-disable-next-line no-console
   console.log("Toast closed with response:", toastResponse);

--- a/examples/next-web/app/modal-demo.tsx
+++ b/examples/next-web/app/modal-demo.tsx
@@ -71,7 +71,7 @@ export const ModalDemo = () => {
       swipeDirection: undefined,
     });
 
-    setResult(describeResult(await entry.promise));
+    setResult(describeResult(await entry));
   };
 
   return (

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
@@ -2,8 +2,12 @@ import type {
   GlobalHideFunction,
   GlobalShowFunction,
   GlobalUpdateFunction,
+  HideReturn,
   ModalChildren,
+  ModalHandle,
   ModalProps,
+  ModalUpdateFunction,
+  NewConfigProps,
 } from "../../constants/types";
 
 import type { ElementType } from "react";
@@ -32,6 +36,28 @@ type ModalStackItem = {
   config: ModalProps;
   hideCallback: (value: unknown) => void;
   hideFunction: (props: unknown) => void;
+};
+
+/**
+ * Hangs the stack-entry controls off the modal's own promise, so callers can
+ * `await magicModal.show(...)` and still reach `modalID`, `update` and `hide`.
+ *
+ * `promise` points back at the handle: it is the deprecated alias that keeps
+ * `const { promise } = magicModal.show(...)` working.
+ */
+const createModalHandle = <T,>(
+  promise: Promise<HideReturn<T>>,
+  controls: {
+    modalID: string;
+    update: ModalUpdateFunction;
+    hide: (data?: T) => void;
+  },
+): ModalHandle<T> => {
+  // `Object.assign` returns the intersection, which is every part of
+  // `ModalHandle` except the self-referential `promise` assigned below.
+  const handle = Object.assign(promise, controls) as ModalHandle<T>;
+  handle.promise = handle;
+  return handle;
 };
 /**
  * @description A magic portal that should stay on the top of the app component hierarchy for the modal to be displayed.
@@ -131,14 +157,21 @@ export const createMagicModalPortal = (
     );
 
     const show = useCallback<GlobalShowFunction>(
-      (newComponent, newConfig) => {
+      // Written generic rather than relying on the contextual type, so `T`
+      // has a name inside and the handle can be built without casting it.
+      <T,>(
+        newComponent: ModalChildren,
+        newConfig?: NewConfigProps,
+      ): ModalHandle<T> => {
         const modalID = generatePseudoRandomID();
 
         let hideCallback: (value: unknown) => void = () => {
           // Empty function
         };
-        const hidePromise = new Promise((resolve) => {
-          hideCallback = resolve;
+        // The stack is payload-agnostic: it resolves whatever the hide caller
+        // passed, and `T` is what the caller declared that payload to be.
+        const hidePromise = new Promise<HideReturn<T>>((resolve) => {
+          hideCallback = resolve as (value: unknown) => void;
         });
 
         const newModal = {
@@ -153,15 +186,19 @@ export const createMagicModalPortal = (
 
         setModals((prevModals) => [...prevModals, newModal]);
 
-        return {
-          // This is already typed by the GlobalShowFunction type Generic
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          promise: hidePromise as any,
+        return createModalHandle<T>(hidePromise, {
           modalID,
-          update: (updatedComponent: ModalChildren) => {
+          update: (updatedComponent) => {
             update(updatedComponent, { modalID });
           },
-        } as const;
+          hide: (data) => {
+            // Same wiring the `useMagicModal` hook uses from inside the modal.
+            newModal.hideFunction({
+              reason: MagicModalHideReason.INTENTIONAL_HIDE,
+              data,
+            });
+          },
+        });
       },
       [_hide, update],
     );

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal.test.tsx
@@ -1,4 +1,4 @@
-import type { HookHideFunction } from "../../constants/types";
+import type { HookHideFunction, ModalHandle } from "../../constants/types";
 
 import React, { useEffect } from "react";
 import { BackHandler, Pressable, Text } from "react-native";
@@ -76,6 +76,110 @@ describe("MagicModalPortal", () => {
       data: { answer: 42 },
     });
     expect(screen.queryByTestId("second")).toBeNull();
+  });
+
+  it("resolves the handle itself when it is awaited", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<{ answer: number }> | undefined;
+
+    act(() => {
+      handle = magicModal.show<{ answer: number }>(() => (
+        <ModalContent testID="awaited" />
+      ));
+    });
+
+    await expect(screen.findByTestId("awaited")).resolves.toBeTruthy();
+
+    act(() => {
+      magicModal.hide({ answer: 42 }, { modalID: handle?.modalID });
+    });
+
+    await expect(handle).resolves.toStrictEqual({
+      reason: MagicModalHideReason.INTENTIONAL_HIDE,
+      data: { answer: 42 },
+    });
+    expect(screen.queryByTestId("awaited")).toBeNull();
+  });
+
+  it("keeps the legacy promise property as an alias of the handle", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<unknown> | undefined;
+    let promise: Promise<unknown> | undefined;
+    let modalID = "";
+    let update: (component: React.FC) => void = () => {};
+
+    act(() => {
+      handle = magicModal.show(() => <ModalContent testID="legacy" />);
+      // The destructuring every existing caller writes.
+      ({ promise, modalID, update } = handle);
+    });
+
+    expect(promise).toBe(handle);
+    expect(modalID).toBe(handle?.modalID);
+
+    act(() => {
+      update(() => <ModalContent testID="legacy-updated" />);
+    });
+
+    await expect(screen.findByTestId("legacy-updated")).resolves.toBeTruthy();
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    await expect(promise).resolves.toStrictEqual({
+      reason: MagicModalHideReason.INTENTIONAL_HIDE,
+      data: undefined,
+    });
+  });
+
+  it("swaps content through the handle's update", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<unknown> | undefined;
+
+    act(() => {
+      handle = magicModal.show(() => <ModalContent testID="handle-before" />);
+    });
+
+    await expect(screen.findByTestId("handle-before")).resolves.toBeTruthy();
+
+    act(() => {
+      handle?.update(() => <ModalContent testID="handle-after" />);
+    });
+
+    await expect(screen.findByTestId("handle-after")).resolves.toBeTruthy();
+    expect(screen.queryByTestId("handle-before")).toBeNull();
+
+    act(() => {
+      magicModal.hideAll();
+    });
+  });
+
+  it("closes the modal through the handle's hide", async () => {
+    render(<MagicModalPortal />);
+
+    let handle: ModalHandle<{ answer: number }> | undefined;
+
+    act(() => {
+      handle = magicModal.show<{ answer: number }>(() => (
+        <ModalContent testID="handle-hide" />
+      ));
+    });
+
+    await expect(screen.findByTestId("handle-hide")).resolves.toBeTruthy();
+
+    act(() => {
+      handle?.hide({ answer: 7 });
+    });
+
+    await expect(handle).resolves.toStrictEqual({
+      reason: MagicModalHideReason.INTENTIONAL_HIDE,
+      data: { answer: 7 },
+    });
+    expect(screen.queryByTestId("handle-hide")).toBeNull();
   });
 
   it("resolves an intentional hide from the modal-scoped hook", async () => {

--- a/packages/modal/src/constants/types.ts
+++ b/packages/modal/src/constants/types.ts
@@ -12,7 +12,7 @@ export type ModalChildren = React.FC;
 export type Direction = "up" | "down" | "left" | "right";
 
 /**
- * The discriminated result resolved by `magicModal.show<T>().promise`.
+ * The discriminated result resolved by `magicModal.show<T>()`.
  * `data` exists only when the modal was intentionally hidden.
  */
 export type HideReturn<T> =
@@ -154,11 +154,53 @@ export enum MagicModalHideReason {
   GLOBAL_HIDE_ALL = "GLOBAL_HIDE_ALL",
 }
 
+/**
+ * What `magicModal.show<T>()` hands back: the modal's result promise, with the
+ * controls for that stack entry hanging off it.
+ *
+ * Await it directly to get the {@link HideReturn}, or keep it around to drive
+ * the modal while it is open.
+ *
+ * ```tsx
+ * const handle = magicModal.show<Confirmation>(ConfirmationModal);
+ * handle.update(() => <ConfirmationModal step={2} />);
+ * const result = await handle;
+ * ```
+ *
+ * The controls live on the promise object itself, so anything that adopts the
+ * handle hands back a plain promise without them. Returning it from an `async`
+ * function is the common case:
+ *
+ * ```tsx
+ * // `modalID`, `update` and `hide` are gone from what the caller receives.
+ * const open = async () => magicModal.show(ConfirmationModal);
+ * ```
+ *
+ * Return the handle from a non-async function, or await it where you open it.
+ */
+export type ModalHandle<T> = Promise<HideReturn<T>> & {
+  /** Identifies this stack entry for `magicModal.hide` and `magicModal.update`. */
+  modalID: string;
+
+  /** Swaps the content of this modal while it stays open. */
+  update: (next: ModalChildren) => void;
+
+  /**
+   * Closes this modal from outside it, resolving the handle with
+   * {@link MagicModalHideReason.INTENTIONAL_HIDE} and `data`. Inside modal
+   * content, prefer `hide` from `useMagicModal`.
+   */
+  hide: (data?: T) => void;
+
+  /**
+   * @deprecated await the handle directly. Kept as an alias of the handle
+   * itself so existing `const { promise } = magicModal.show(...)` code keeps
+   * working.
+   */
+  promise: Promise<HideReturn<T>>;
+};
+
 export type GlobalShowFunction = <T>(
   newComponent: ModalChildren,
   newConfig?: NewConfigProps,
-) => {
-  promise: Promise<HideReturn<T>>;
-  modalID: string;
-  update: ModalUpdateFunction;
-};
+) => ModalHandle<T>;

--- a/packages/modal/src/index.react-native.ts
+++ b/packages/modal/src/index.react-native.ts
@@ -4,6 +4,7 @@ export {
   type HideReturn,
   type NewConfigProps,
   type ModalChildren,
+  type ModalHandle,
   type Direction,
   type ModalProps,
 } from "./constants/types";

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -4,6 +4,7 @@ export {
   type HideReturn,
   type NewConfigProps,
   type ModalChildren,
+  type ModalHandle,
   type Direction,
   type ModalProps,
 } from "./constants/types";

--- a/packages/modal/src/utils/magic-modal-handler.ts
+++ b/packages/modal/src/utils/magic-modal-handler.ts
@@ -9,9 +9,11 @@ import type {
 import React from "react";
 
 import {
-  // HideReturn is used in JS Doc
+  // HideReturn and ModalHandle are used in JS Doc
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   HideReturn,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ModalHandle,
 } from "../constants/types";
 
 export const magicModalRef = React.createRef<IModal>();
@@ -73,9 +75,7 @@ export type IModal = {
  *   );
  * };
  *
- * const result = await magicModal.show<{ message: string }>(
- *   ExampleModal,
- * ).promise;
+ * const result = await magicModal.show<{ message: string }>(ExampleModal);
  *
  * if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE) {
  *   console.log(result.data.message);
@@ -87,7 +87,15 @@ export const magicModal = {
    * @description Pushes a modal to the Stack, it will be displayed on top of the others.
    * @param newComponent Receives a function that returns a modal component.
    * @param newConfig Receives {@link NewConfigProps} to override the default configs.
-   * @returns `promise`, which resolves with the {@link hide} props when the Modal is closed (if it were closed automatically, without the manual use of {@link hide}, the return would be one of {@link HideReturn}), the `modalID`, and an `update` function that swaps the modal's content while it stays open.
+   * @returns A {@link ModalHandle}: the promise that resolves with the {@link hide} props when the
+   * Modal is closed (if it were closed automatically, without the manual use of {@link hide}, the
+   * return would be one of {@link HideReturn}), carrying `modalID`, an `update` function that swaps
+   * the modal's content while it stays open, a `hide` function that closes this entry, and a
+   * deprecated `promise` alias of the handle itself.
+   * @example
+   * ```js
+   * const result = await magicModal.show(() => <ExampleModal />);
+   * ```
    * @example
    * ```js
    * const { update } = magicModal.show(() => <ExampleModal step={1} />);
@@ -96,6 +104,10 @@ export const magicModal = {
    * Prefer keeping state inside the modal component when you can. `update` is for data that
    * lives outside of it and can't reach in. The content is a new component, so it mounts from
    * scratch: anything the old one held in `useState` is gone.
+   *
+   * The controls hang off the promise, so awaiting the handle strips them. Returning it from an
+   * `async` function gives the caller a plain promise: return it from a normal function, or await
+   * it where the modal is opened.
    */
   show,
   /**
@@ -116,7 +128,7 @@ export const magicModal = {
    * @example
    * ```js
    * magicModal.disableFullWindowOverlay();
-   * await magicModal.show(() => <ExampleModal />).promise;
+   * await magicModal.show(() => <ExampleModal />);
    * magicModal.enableFullWindowOverlay();
    * ```
    * @platform ios
@@ -127,7 +139,7 @@ export const magicModal = {
    * @example
    * ```js
    * magicModal.disableFullWindowOverlay();
-   * await magicModal.show(() => <ExampleModal />).promise;
+   * await magicModal.show(() => <ExampleModal />);
    * magicModal.enableFullWindowOverlay();
    * ```
    * @platform ios

--- a/registry/README.md
+++ b/registry/README.md
@@ -36,7 +36,7 @@ import { MagicModalHideReason } from "react-native-magic-modal";
 
 import { showMagicModal } from "@/components/magic-modal";
 
-const { promise } = showMagicModal({
+const result = await showMagicModal({
   title: "Delete this project?",
   description: "This cannot be undone.",
   actions: [
@@ -47,8 +47,6 @@ const { promise } = showMagicModal({
     },
   ],
 });
-
-const result = await promise;
 
 if (result.reason === MagicModalHideReason.BACKDROP_PRESS) {
   // The user pressed outside the dialog.

--- a/registry/test/magic-modal.type-test.tsx
+++ b/registry/test/magic-modal.type-test.tsx
@@ -3,7 +3,7 @@ import { MagicModalHideReason } from "react-native-magic-modal";
 import { showMagicModal } from "../magic-modal";
 
 export async function typecheckMagicModalResult() {
-  const { promise } = showMagicModal({
+  const handle = showMagicModal({
     title: "Delete this project?",
     actions: [
       {
@@ -14,7 +14,7 @@ export async function typecheckMagicModalResult() {
     ],
   });
 
-  const result = await promise;
+  const result = await handle;
 
   if (result.reason === MagicModalHideReason.INTENTIONAL_HIDE && result.data.type === "action") {
     const action: "delete" = result.data.value;


### PR DESCRIPTION
📝 **DESCRIPTION:**

`magicModal.show()` now returns an awaitable `ModalHandle<T>`: the result promise itself, with `modalID`, `update`, and `hide` attached. `await magicModal.show(...)` replaces `await magicModal.show(...).promise`. Existing destructuring keeps working; `promise` is now a deprecated alias of the handle. JSDoc and docs warn that returning the handle from an `async` function collapses it to a plain promise.

The second commit migrates every remaining `.promise` call site to the new style: 17 files across the docs app, the landing page components, the guides and reference pages, both examples, and the registry. One kitchen-sink call site keeps the deprecated alias on purpose, with a comment, as a live backward-compatibility demo.

The FullWindowOverlay lazy-mount and the README refresh are stacked on this branch as separate PRs.

🖼 **PRINTS & GIFS:**

No visual changes intended. The landing page's "What `magicModal.show()` returns" section now describes the handle shape instead of the old `{ promise, modalID, update }` object.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

Yes: one API change and the call-site migration it implies, in two commits (core + sweep).

##### Awesome tests or e2e (avoid `shallow` rendering)

4 new tests: awaiting the handle, legacy `.promise` destructuring (asserting `promise` is the same object as the handle), `handle.update`, and `handle.hide(data)` resolving with `INTENTIONAL_HIDE`. 55 tests passing overall, including the 16 pre-existing `.promise` tests, untouched. Repo-wide `pnpm typecheck` covers the migrated docs app and examples.
