### PR TITLE
fix(modal): mount the iOS overlay only while modals are on screen

### DIFF
--- a/apps/docs/content/docs/guides/native-overlays.mdx
+++ b/apps/docs/content/docs/guides/native-overlays.mdx
@@ -6,6 +6,11 @@ description: Control whether Magic Modal renders above native modal screens such
 On iOS, Magic Modal can use a full-window overlay so application modals stay above native screens.
 This is enabled by default.
 
+The overlay is a native window, so the portal only mounts it while the stack has something in it.
+An idle app has no extra window in its accessibility tree, which keeps screen readers and UI test
+selectors on the real screen. It stays mounted through the closing animation and unmounts once the
+last modal has finished animating out.
+
 Disable it before an interaction that should sit behind a native picker:
 
 ```tsx

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
@@ -19,9 +19,14 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from "react";
 import { BackHandler, Platform, StyleSheet, View } from "react-native";
 
+import {
+  ANIMATION_DURATION_IN_MS,
+  OVERLAY_UNMOUNT_GRACE_IN_MS,
+} from "../../constants/animations";
 import { defaultConfig } from "../../constants/default-config";
 import { MagicModalHideReason } from "../../constants/types";
 import { magicModalRef } from "../../utils/magic-modal-handler";
@@ -122,6 +127,12 @@ export const createMagicModalPortal = ({
     const [modals, setModals] = React.useState<ModalStackItem[]>([]);
     const [fullWindowOverlayEnabled, setFullWindowOverlayEnabled] =
       React.useState(true);
+    // Mounting the overlay permanently creates a native UIWindow that owns the
+    // accessibility tree even with an empty stack, so it is mounted on demand.
+    const [isOverlayMounted, setIsOverlayMounted] = React.useState(false);
+    // The exit timing of whatever is currently on the stack, kept so the
+    // unmount delay is still readable once the stack is empty.
+    const exitTimingRef = useRef(ANIMATION_DURATION_IN_MS);
 
     const disableFullWindowOverlay = useCallback(() => {
       setFullWindowOverlayEnabled(false);
@@ -238,6 +249,9 @@ export const createMagicModalPortal = ({
           },
         } satisfies ModalStackItem;
 
+        // Batched with the stack update, so the overlay and the modal land in
+        // the same commit and the entering animation runs once, inside it.
+        setIsOverlayMounted(true);
         setModals((prevModals) => [...prevModals, newModal]);
 
         return createModalHandle<T>(hidePromise, {
@@ -256,6 +270,48 @@ export const createMagicModalPortal = ({
       },
       [_hide, update],
     );
+
+    /**
+     * Keeps the overlay alive through the closing animation.
+     *
+     * A hidden entry leaves state immediately, but its Reanimated `exiting`
+     * animation is still playing. Unmounting the overlay right then tears down
+     * the native window mid-animation: the closing modal blinks, drops out of
+     * the top layer, and loses focus. So the unmount waits out the exit timing
+     * of whatever was on the stack.
+     *
+     * Anything that repopulates the stack, a `show` during the wait included,
+     * changes `modals` and cancels the pending unmount through the cleanup, so
+     * back-to-back modals never blink.
+     *
+     * The count is of live entries, matching `hasLiveModals` below: an entry
+     * the browser chrome parks as `isExiting` is already off the stack for
+     * every other purpose. It reads the same on the overlay's own path, which
+     * is iOS-only and where the native chrome drops entries on the spot, and it
+     * keeps the wait timed off the config on either chrome.
+     */
+    useEffect(() => {
+      const liveModals = getLiveModals(modals);
+
+      if (liveModals.length > 0) {
+        exitTimingRef.current = Math.max(
+          ...liveModals.map((modal) => modal.config.animationOutTiming),
+        );
+        return;
+      }
+
+      if (!isOverlayMounted) {
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        setIsOverlayMounted(false);
+      }, exitTimingRef.current + OVERLAY_UNMOUNT_GRACE_IN_MS);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, [isOverlayMounted, modals]);
 
     useEffect(() => {
       if (Platform.OS === "web") {
@@ -346,7 +402,7 @@ export const createMagicModalPortal = ({
     }, [modals, removeModal]);
 
     const Overlay =
-      fullWindowOverlayEnabled && Platform.OS === "ios"
+      fullWindowOverlayEnabled && isOverlayMounted && Platform.OS === "ios"
         ? FullWindowOverlay
         : React.Fragment;
 
@@ -354,8 +410,9 @@ export const createMagicModalPortal = ({
     // tree: as far as a screen reader is concerned they are already gone.
     const hasLiveModals = getLiveModals(modals).length > 0;
 
-    /* This needs to always be rendered, if we make it conditionally render based on ModalContent too,
-     the modal will have zIndex issues on react-navigation modals. */
+    /* The View below stays rendered whether or not there are modals: making it
+     conditional on ModalContent gives the modal zIndex issues on
+     react-navigation modals. Only the overlay wrapper comes and goes. */
     return (
       <Overlay>
         <View

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal.overlay.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal.overlay.test.tsx
@@ -1,0 +1,237 @@
+import type { ElementType, ReactNode } from "react";
+
+import React from "react";
+import { Platform, Text, View } from "react-native";
+
+import {
+  act,
+  render as rntlRender,
+  screen,
+} from "@testing-library/react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import {
+  ANIMATION_DURATION_IN_MS,
+  OVERLAY_UNMOUNT_GRACE_IN_MS,
+} from "../../constants/animations";
+import { magicModal } from "../../utils/magic-modal-handler";
+import { MagicModal } from "../magic-modal";
+import { createMagicModalPortal } from "./magic-modal-portal-base";
+
+/**
+ * The iOS FullWindowOverlay is a native window. Left mounted with an empty
+ * stack it owns the accessibility tree for the whole app, which is why the
+ * portal only wraps itself in one while there is something to show.
+ *
+ * `createMagicModalPortal` takes the overlay as an argument, so these tests
+ * pass a stub with a testID instead of reaching for react-native-screens. The
+ * chrome is the Reanimated one the native portal injects, and with it the
+ * default `leaveStack`: a dismissed entry leaves the stack on the spot.
+ */
+const OVERLAY_TEST_ID = "full-window-overlay-stub";
+const includeHiddenElements = { includeHiddenElements: true } as const;
+
+const FullWindowOverlayStub: ElementType = ({
+  children,
+}: {
+  children?: ReactNode;
+}) => <View testID={OVERLAY_TEST_ID}>{children}</View>;
+
+const TestPortal = createMagicModalPortal({
+  FullWindowOverlay: FullWindowOverlayStub,
+  StackEntry: MagicModal,
+});
+
+const ModalContent = () => <Text testID="overlay-modal">Taveira</Text>;
+
+const render = () =>
+  rntlRender(
+    <GestureHandlerRootView>
+      <TestPortal />
+    </GestureHandlerRootView>,
+  );
+
+const queryOverlay = () =>
+  screen.queryByTestId(OVERLAY_TEST_ID, includeHiddenElements);
+
+/** The window the portal waits out before it drops the native overlay. */
+const exitWindow = (animationOutTiming = ANIMATION_DURATION_IN_MS): number =>
+  animationOutTiming + OVERLAY_UNMOUNT_GRACE_IN_MS;
+
+const advanceBy = (ms: number) => {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+};
+
+// `Platform.OS` is typed as the literal of whichever platform the type
+// resolution picked, so it is widened here to swap in another one.
+const platformModule = Platform as unknown as { OS: string };
+
+describe("MagicModalPortal full window overlay", () => {
+  let platform: { replaceValue: (value: string) => void; restore: () => void };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    platform = jest.replaceProperty(platformModule, "OS", "ios");
+  });
+
+  afterEach(() => {
+    act(() => {
+      magicModal.hideAll();
+    });
+    // Drains the unmount the line above just scheduled, so it cannot fire
+    // outside `act` once the timers go back to real.
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    platform.restore();
+  });
+
+  it("leaves the overlay unmounted while the stack is empty", () => {
+    render();
+
+    expect(
+      screen.getByTestId("magic-modal-portal", includeHiddenElements),
+    ).toBeTruthy();
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("wraps the portal in the overlay once a modal is shown", () => {
+    render();
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    expect(queryOverlay()).toBeTruthy();
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+    // The stack lives inside the overlay, not beside it.
+    expect(
+      screen.getByTestId(OVERLAY_TEST_ID).findByProps({
+        testID: "magic-modal-portal",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the overlay mounted while the closing modal animates out", () => {
+    render();
+
+    let modalID = "";
+    act(() => {
+      modalID = magicModal.show(ModalContent).modalID;
+    });
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    // The entry is gone from state, the exit animation is not.
+    expect(screen.queryByTestId("overlay-modal")).toBeNull();
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(exitWindow() - 1);
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(1);
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("waits out a longer animationOutTiming before unmounting", () => {
+    render();
+
+    const animationOutTiming = 1000;
+    let modalID = "";
+
+    act(() => {
+      modalID = magicModal.show(ModalContent, { animationOutTiming }).modalID;
+    });
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    advanceBy(exitWindow() + 1);
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(exitWindow(animationOutTiming));
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("unmounts the overlay after hideAll clears the stack", () => {
+    render();
+
+    act(() => {
+      magicModal.show(ModalContent);
+      magicModal.show(ModalContent);
+    });
+
+    act(() => {
+      magicModal.hideAll();
+    });
+
+    expect(queryOverlay()).toBeTruthy();
+
+    advanceBy(exitWindow());
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("cancels the pending unmount when another modal opens during the exit window", () => {
+    render();
+
+    let modalID = "";
+    act(() => {
+      modalID = magicModal.show(ModalContent).modalID;
+    });
+
+    act(() => {
+      magicModal.hide(undefined, { modalID });
+    });
+
+    advanceBy(exitWindow() - 10);
+    expect(queryOverlay()).toBeTruthy();
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    // Past the deadline the first modal had scheduled: no blink between the two.
+    advanceBy(exitWindow());
+    expect(queryOverlay()).toBeTruthy();
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+  });
+
+  it("never mounts the overlay outside iOS", () => {
+    platform.replaceValue("android");
+    render();
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+    expect(queryOverlay()).toBeNull();
+  });
+
+  it("keeps the overlay off while it is globally disabled", () => {
+    render();
+
+    act(() => {
+      magicModal.disableFullWindowOverlay();
+    });
+
+    act(() => {
+      magicModal.show(ModalContent);
+    });
+
+    expect(screen.getByTestId("overlay-modal")).toBeTruthy();
+    expect(queryOverlay()).toBeNull();
+
+    act(() => {
+      magicModal.enableFullWindowOverlay();
+    });
+
+    expect(queryOverlay()).toBeTruthy();
+  });
+});

--- a/packages/modal/src/constants/animations.ts
+++ b/packages/modal/src/constants/animations.ts
@@ -1,1 +1,13 @@
 export const ANIMATION_DURATION_IN_MS = 250;
+
+/**
+ * Extra time the iOS FullWindowOverlay stays mounted after the last modal
+ * leaves the stack.
+ *
+ * A stack entry is dropped from state as soon as it is hidden, while its
+ * Reanimated `exiting` animation keeps playing on the UI thread. Reanimated
+ * does not bridge a completion callback back to JS for layout animations, so
+ * the overlay unmount is timed off the entry's `animationOutTiming` plus this
+ * margin instead of being observed.
+ */
+export const OVERLAY_UNMOUNT_GRACE_IN_MS = 50;


### PR DESCRIPTION
📝 **DESCRIPTION:**

The iOS `FullWindowOverlay` now mounts only while modals are on screen. It used to mount permanently: the native UIWindow it creates owns the accessibility tree even with no modal open, which breaks a11y selectors in e2e tools like maestro and keeps a permanent extra layer over the app.

Stacked on #328 (base branch), which reworks the same file.

Design, for review:

- `isOverlayMounted` starts `false`. `show()` sets it `true` in the same batch as the stack push, so the overlay and the first modal land in one React commit and the entering animation runs inside the overlay.
- A hidden entry leaves state immediately while its Reanimated `exiting` animation is still playing, so unmounting on `modals.length === 0` alone would tear the native window down mid-close (blink, drop out of the top layer, focus loss). Instead, an effect records `Math.max(animationOutTiming)` of the live stack in a ref and, when the stack empties, schedules the unmount at that timing plus `OVERLAY_UNMOUNT_GRACE_IN_MS` (50ms).
- The effect's cleanup cancels the pending unmount whenever `modals` changes, so a `show()` during the grace window keeps the overlay mounted with no blink between back-to-back modals.
- The inner `View` still renders unconditionally. The old comment said conditional rendering caused zIndex issues with react-navigation modals; that behavior is preserved, only the overlay wrapper is conditional now.

Known limitation: the unmount is timed, because Reanimated does not bridge layout-animation completion callbacks back to JS. A saturated UI thread could in theory stretch the exit animation past the window; the knob for that is the documented `OVERLAY_UNMOUNT_GRACE_IN_MS` constant.

Suggested review focus: the react-navigation zIndex scenario (worth a manual check in the kitchen-sink app), the batched mount in `show()`, and the grace-window effect's dependency array.

🖼 **PRINTS & GIFS:**

No visual changes intended. The observable difference is in the accessibility tree: with no modal open, the app is no longer wrapped by a native overlay window.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

Yes: overlay mount lifecycle only (`magic-modal-portal-base.tsx`, one constant in `animations.ts`, one docs page note).

##### Awesome tests or e2e (avoid `shallow` rendering)

8 new overlay-lifecycle tests with fake timers and a stub overlay component (no react-native-screens dependency): mount on show, still mounted right after hide and at `exitWindow - 1ms`, unmounted at the window, custom `animationOutTiming: 1000` respected, show-during-grace cancelling the unmount, `hideAll`, android, `disableFullWindowOverlay`. Negative controls: reverting to the always-mounted wrapper fails 4 of 8; gating on `modals.length > 0` alone fails 3 of 8.
