### PR TITLE
feat(docs): serve the docs from magic-modal.gabrieltaveira.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img
     alt="A rating flow moving from magicModal.show to a typed close result"
-    src="https://raw.githubusercontent.com/GSTJ/react-native-magic-modal/main/media/magic-modal-demo.gif"
+    src="https://raw.githubusercontent.com/GSTJ/magic-modal/main/media/magic-modal-demo.gif"
   />
 </p>
 
@@ -10,12 +10,12 @@
 <p align="center">
   <a aria-label="npm version" href="https://www.npmjs.com/package/react-native-magic-modal"><img alt="npm version" src="https://shieldcn.dev/npm/react-native-magic-modal.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
   <a aria-label="npm downloads" href="https://www.npmjs.com/package/react-native-magic-modal"><img alt="npm downloads" src="https://shieldcn.dev/npm/react-native-magic-modal/downloads.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
-  <a aria-label="GitHub stars" href="https://github.com/GSTJ/react-native-magic-modal/stargazers"><img alt="GitHub stars" src="https://shieldcn.dev/github/GSTJ/react-native-magic-modal/stars.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
-  <a aria-label="license" href="https://github.com/GSTJ/react-native-magic-modal/blob/main/LICENSE"><img alt="license" src="https://shieldcn.dev/github/GSTJ/react-native-magic-modal/license.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
+  <a aria-label="GitHub stars" href="https://github.com/GSTJ/magic-modal/stargazers"><img alt="GitHub stars" src="https://shieldcn.dev/github/GSTJ/magic-modal/stars.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
+  <a aria-label="license" href="https://github.com/GSTJ/magic-modal/blob/main/LICENSE"><img alt="license" src="https://shieldcn.dev/github/GSTJ/magic-modal/license.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
 </p>
 
 <p align="center">
-  <a href="https://gstj.github.io/react-native-magic-modal/docs/">Docs</a> | <a href="https://github.com/gstj/react-native-magic-modal">GitHub</a> | <a href="https://gstj.github.io/react-native-magic-modal/docs/faq/">FAQ</a> | <a href="https://medium.com/@gabrieltaveira/you-have-been-using-react-native-modals-wrong-9b8c17de2f96">Article</a>
+  <a href="https://gstj.github.io/magic-modal/docs/">Docs</a> | <a href="https://github.com/gstj/magic-modal">GitHub</a> | <a href="https://gstj.github.io/magic-modal/docs/faq/">FAQ</a> | <a href="https://medium.com/@gabrieltaveira/you-have-been-using-react-native-modals-wrong-9b8c17de2f96">Article</a>
 </p>
 
 ## How it works
@@ -57,7 +57,7 @@ pnpm add react-native-magic-modal
 npx expo install react-native-gesture-handler react-native-reanimated react-native-worklets react-dom react-native-web @expo/metro-runtime
 ```
 
-Read the [Expo guide](https://gstj.github.io/react-native-magic-modal/docs/platforms/expo/) for the
+Read the [Expo guide](https://gstj.github.io/magic-modal/docs/platforms/expo/) for the
 portal and web command.
 
 ### Expo iOS
@@ -75,7 +75,7 @@ npx expo install react-native-gesture-handler react-native-reanimated react-nati
 ```
 
 iOS and Android use the same native dependency set. The
-[native guide](https://gstj.github.io/react-native-magic-modal/docs/platforms/ios-android/) covers
+[native guide](https://gstj.github.io/magic-modal/docs/platforms/ios-android/) covers
 pods, Android back handling, and iOS overlays.
 
 ### Next.js
@@ -85,11 +85,11 @@ pnpm add react-native-magic-modal react-native react-native-web react-native-ges
 ```
 
 Copy the validated alias, extension order, and Client Component setup from the
-[Next.js guide](https://gstj.github.io/react-native-magic-modal/docs/platforms/nextjs/). A runnable
+[Next.js guide](https://gstj.github.io/magic-modal/docs/platforms/nextjs/). A runnable
 App Router consumer lives in [`examples/next-web`](examples/next-web).
 
 For bare React Native, follow the
-[installation guide](https://gstj.github.io/react-native-magic-modal/docs/getting-started/installation/).
+[installation guide](https://gstj.github.io/magic-modal/docs/getting-started/installation/).
 
 ## Mount the portal
 
@@ -110,7 +110,7 @@ export default function App() {
 ```
 
 With Expo Router, put the same structure in the root `app/_layout.tsx`. Next.js mounts the portal
-inside a Client Component as shown in the [web setup](https://gstj.github.io/react-native-magic-modal/docs/platforms/nextjs/).
+inside a Client Component as shown in the [web setup](https://gstj.github.io/magic-modal/docs/platforms/nextjs/).
 
 ## Return typed data
 
@@ -160,15 +160,15 @@ accessibility escape action. TypeScript exposes `data` after the caller narrows 
 
 ## Documentation
 
-- [Expo Web, iOS, and Android](https://gstj.github.io/react-native-magic-modal/docs/platforms/expo/)
-- [Next.js and React Native Web](https://gstj.github.io/react-native-magic-modal/docs/platforms/nextjs/)
-- [Modal flows and stacks](https://gstj.github.io/react-native-magic-modal/docs/guides/modal-flows/)
-- [Hide results](https://gstj.github.io/react-native-magic-modal/docs/reference/hide-results/)
-- [Accessibility](https://gstj.github.io/react-native-magic-modal/docs/guides/accessibility/)
-- [Advanced content replacement](https://gstj.github.io/react-native-magic-modal/docs/guides/updating-content/)
+- [Expo Web, iOS, and Android](https://gstj.github.io/magic-modal/docs/platforms/expo/)
+- [Next.js and React Native Web](https://gstj.github.io/magic-modal/docs/platforms/nextjs/)
+- [Modal flows and stacks](https://gstj.github.io/magic-modal/docs/guides/modal-flows/)
+- [Hide results](https://gstj.github.io/magic-modal/docs/reference/hide-results/)
+- [Accessibility](https://gstj.github.io/magic-modal/docs/guides/accessibility/)
+- [Advanced content replacement](https://gstj.github.io/magic-modal/docs/guides/updating-content/)
 
 The [kitchen-sink Expo app](examples/kitchen-sink) contains runnable native flows. The
-[interactive site](https://gstj.github.io/react-native-magic-modal/) runs the package in the
+[interactive site](https://gstj.github.io/magic-modal/) runs the package in the
 browser.
 
 ## FAQ
@@ -204,12 +204,12 @@ Inside modal content, use `useMagicModal().hide()`.
 ### How do I render below a native picker on iOS?
 
 Temporarily call `magicModal.disableFullWindowOverlay()`. Restore it in a `finally` block after the
-picker closes. The [native overlay guide](https://gstj.github.io/react-native-magic-modal/docs/guides/native-overlays/)
+picker closes. The [native overlay guide](https://gstj.github.io/magic-modal/docs/guides/native-overlays/)
 contains the complete pattern.
 
 ## Contributors
 
-[See everyone who has contributed](https://github.com/GSTJ/react-native-magic-modal/graphs/contributors)
+[See everyone who has contributed](https://github.com/GSTJ/magic-modal/graphs/contributors)
 and read the [contributing guide](CONTRIBUTING.md).
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a Vulnerability
 
 Report it privately through GitHub's advisory form:
-https://github.com/GSTJ/react-native-magic-modal/security/advisories/new
+https://github.com/GSTJ/magic-modal/security/advisories/new
 
 Don't open a public issue for a security problem.
 

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -59,7 +59,7 @@ export default function HomePage() {
           <a
             aria-label="Magic Modal on GitHub"
             className="mm-nav-github"
-            href="https://github.com/GSTJ/react-native-magic-modal"
+            href="https://github.com/GSTJ/magic-modal"
             rel="noreferrer"
             target="_blank"
           >
@@ -114,7 +114,7 @@ export default function HomePage() {
 
       <aside aria-label="Project activity" className="mm-proof">
         <a
-          href="https://github.com/GSTJ/react-native-magic-modal"
+          href="https://github.com/GSTJ/magic-modal"
           rel="noreferrer"
           target="_blank"
         >
@@ -136,7 +136,7 @@ export default function HomePage() {
           <ArrowUpRight aria-hidden="true" size={14} />
         </a>
         <a
-          href="https://github.com/GSTJ/react-native-magic-modal/releases/latest"
+          href="https://github.com/GSTJ/magic-modal/releases/latest"
           rel="noreferrer"
           target="_blank"
         >
@@ -147,7 +147,7 @@ export default function HomePage() {
           <ArrowUpRight aria-hidden="true" size={14} />
         </a>
         <a
-          href="https://github.com/GSTJ/react-native-magic-modal/blob/main/LICENSE"
+          href="https://github.com/GSTJ/magic-modal/blob/main/LICENSE"
           rel="noreferrer"
           target="_blank"
         >
@@ -223,7 +223,7 @@ export default function HomePage() {
             </p>
           </article>
           <a
-            href="https://github.com/GSTJ/react-native-magic-modal/blob/main/packages/modal/src/components/MagicModalPortal/magic-modal-portal.test.tsx"
+            href="https://github.com/GSTJ/magic-modal/blob/main/packages/modal/src/components/MagicModalPortal/magic-modal-portal.test.tsx"
             rel="noreferrer"
             target="_blank"
           >
@@ -499,14 +499,14 @@ export default function HomePage() {
         <nav aria-label="Project">
           <strong>Project</strong>
           <a
-            href="https://github.com/GSTJ/react-native-magic-modal"
+            href="https://github.com/GSTJ/magic-modal"
             rel="noreferrer"
             target="_blank"
           >
             GitHub
           </a>
           <a
-            href="https://github.com/GSTJ/react-native-magic-modal/releases"
+            href="https://github.com/GSTJ/magic-modal/releases"
             rel="noreferrer"
             target="_blank"
           >
@@ -520,7 +520,7 @@ export default function HomePage() {
             npm
           </a>
           <a
-            href="https://github.com/GSTJ/react-native-magic-modal/issues"
+            href="https://github.com/GSTJ/magic-modal/issues"
             rel="noreferrer"
             target="_blank"
           >

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -36,7 +36,7 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
       <div className="page-actions">
         <MarkdownCopyButton markdownUrl={markdownUrl} />
         <ViewOptionsPopover
-          githubUrl={`https://github.com/GSTJ/react-native-magic-modal/blob/main/apps/docs/content/docs/${page.path}`}
+          githubUrl={`https://github.com/GSTJ/magic-modal/blob/main/apps/docs/content/docs/${page.path}`}
           markdownUrl={markdownUrl}
         />
       </div>

--- a/apps/docs/content/docs/resources.mdx
+++ b/apps/docs/content/docs/resources.mdx
@@ -7,13 +7,13 @@ description: Examples, releases, contributing guidance, and support for Magic Mo
   <Card
     title="Kitchen sink"
     description="Runnable Expo examples for gestures, scroll, keyboard input, custom motion, stacks, and overlays."
-    href="https://github.com/GSTJ/react-native-magic-modal/tree/main/examples/kitchen-sink"
+    href="https://github.com/GSTJ/magic-modal/tree/main/examples/kitchen-sink"
     external
   />
   <Card
     title="Next.js consumer"
     description="A tested App Router consumer with React Native Web, server rendering, hydration, and backdrop dismissal."
-    href="https://github.com/GSTJ/react-native-magic-modal/tree/main/examples/next-web"
+    href="https://github.com/GSTJ/magic-modal/tree/main/examples/next-web"
     external
   />
   <Card
@@ -24,19 +24,19 @@ description: Examples, releases, contributing guidance, and support for Magic Mo
   <Card
     title="Releases"
     description="Version notes, compatibility changes, and migration context."
-    href="https://github.com/GSTJ/react-native-magic-modal/releases"
+    href="https://github.com/GSTJ/magic-modal/releases"
     external
   />
   <Card
     title="Contributing"
     description="Set up the monorepo, run checks, and prepare a focused contribution."
-    href="https://github.com/GSTJ/react-native-magic-modal/blob/main/CONTRIBUTING.md"
+    href="https://github.com/GSTJ/magic-modal/blob/main/CONTRIBUTING.md"
     external
   />
   <Card
     title="Issues"
     description="Report a bug or propose an improvement with a reproducible example."
-    href="https://github.com/GSTJ/react-native-magic-modal/issues"
+    href="https://github.com/GSTJ/magic-modal/issues"
     external
   />
 </Cards>

--- a/apps/docs/lib/project-metadata.ts
+++ b/apps/docs/lib/project-metadata.ts
@@ -4,7 +4,7 @@ export const projectMetadataConfig = {
     "https://api.npmjs.org/downloads/point/last-week/react-native-magic-modal",
   npmPackage: "react-native-magic-modal",
   npmRegistryApi: "https://registry.npmjs.org/react-native-magic-modal/latest",
-  repository: "https://github.com/GSTJ/react-native-magic-modal",
+  repository: "https://github.com/GSTJ/magic-modal",
 } as const;
 
 export type ProjectMetadataSource = "github" | "npmDownloads" | "npmRegistry";

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -8,8 +8,8 @@ const presetSite = defineMagicDocs({
   name: "Magic Modal",
   description:
     "Open a modal from any async flow, await its typed result, and keep concurrent prompts in one ordered stack across web, iOS, and Android.",
-  repository: "https://github.com/GSTJ/react-native-magic-modal",
-  siteUrl: "https://gstj.github.io/react-native-magic-modal",
+  repository: "https://github.com/GSTJ/magic-modal",
+  siteUrl: "https://gstj.github.io/magic-modal",
   packageName: "react-native-magic-modal",
   docsPath: "/docs",
 });

--- a/apps/docs/scripts/write-legacy-redirects.mjs
+++ b/apps/docs/scripts/write-legacy-redirects.mjs
@@ -1,7 +1,7 @@
 import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
-export const deploymentBasePath = "/react-native-magic-modal";
+export const deploymentBasePath = "/magic-modal";
 
 export const legacyRedirects = {
   "enums/MagicModalHideReason.html": "/docs/reference/hide-results/",

--- a/apps/docs/test/project-metadata.test.mjs
+++ b/apps/docs/test/project-metadata.test.mjs
@@ -49,7 +49,7 @@ test("collects project metadata without rounding or fallback metrics", async () 
   assert.equal(metadata.versionLabel, "v9.0.1");
   assert.equal(
     metadata.releaseUrl,
-    "https://github.com/GSTJ/react-native-magic-modal/releases/tag/magic-modal-9.0.1",
+    "https://github.com/GSTJ/magic-modal/releases/tag/magic-modal-9.0.1",
   );
 });
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@11.17.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/GSTJ/react-native-magic-modal.git"
+    "url": "git+https://github.com/GSTJ/magic-modal.git"
   },
   "author": "Gabriel Taveira <gabrielstaveira@gmail.com> (https://github.com/GSTJ)",
   "license": "MIT",
@@ -14,9 +14,9 @@
     "android"
   ],
   "bugs": {
-    "url": "https://github.com/GSTJ/react-native-magic-modal/issues"
+    "url": "https://github.com/GSTJ/magic-modal/issues"
   },
-  "homepage": "https://gstj.github.io/react-native-magic-modal/",
+  "homepage": "https://gstj.github.io/magic-modal/",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -12,15 +12,15 @@
     "react-native-web",
     "web"
   ],
-  "homepage": "https://gstj.github.io/react-native-magic-modal/",
+  "homepage": "https://gstj.github.io/magic-modal/",
   "bugs": {
-    "url": "https://github.com/GSTJ/react-native-magic-modal/issues"
+    "url": "https://github.com/GSTJ/magic-modal/issues"
   },
   "license": "MIT",
   "author": "Gabriel Taveira <gabrielstaveira@gmail.com> (https://github.com/GSTJ)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/GSTJ/react-native-magic-modal.git"
+    "url": "git+https://github.com/GSTJ/magic-modal.git"
   },
   "files": [
     "dist"

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "react-native-magic-modal",
-  "homepage": "https://gstj.github.io/react-native-magic-modal/",
+  "homepage": "https://gstj.github.io/magic-modal/",
   "items": [
     {
       "name": "magic-modal",


### PR DESCRIPTION
📝 **DESCRIPTION:**

The GitHub repo was renamed to `GSTJ/magic-modal`. GitHub redirects the repo URLs, but GitHub Pages does not: every `gstj.github.io/react-native-magic-modal` link now 404s, including the 14 docs links in the README and the `homepage` field npm shows. This sweeps every stale URL in the repo (README, SECURITY, package.jsons, registry.json, docs app metadata/site config) to the new slug. The npm package name is unchanged; the package rename ships separately.

🖼 **PRINTS & GIFS:**

No visual changes.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

Yes: URL string replacements only, 11 files.

##### Awesome tests or e2e (avoid `shallow` rendering)

URL-only change. Repo-wide `pnpm typecheck` passes, the docs `project-metadata` test (which asserts these URLs) passes, and `pnpm format` is clean.