### PR TITLE
feat(modal): cut the web bundle by 83% (32.2 -> 5.3 KB gzip) going full DOM

### DIFF
--- a/apps/docs/content/docs/platforms/nextjs.mdx
+++ b/apps/docs/content/docs/platforms/nextjs.mdx
@@ -213,9 +213,27 @@ its visible heading, controls, form labels, and status messages.
 }
 ```
 
+The modal container itself takes CSS through the `style` option:
+
+```tsx
+magicModal.show(ConfirmationModal, {
+  style: { justifyContent: "flex-end", paddingInline: 16 },
+});
+```
+
+<Callout type="warn" title="`style` is CSS on the web as of v10.1">
+  It used to be `StyleProp<ViewStyle>`, translated at runtime by React Native
+  Web. The browser bundle has no React Native Web in it any more, so `style` is
+  `React.CSSProperties` here: one object, no arrays, and CSS property names —
+  `paddingInline` rather than `paddingHorizontal`, `boxShadow` rather than
+  `shadowColor`. See [Container
+  style](/docs/reference/modal-props#container-style) for the full list. The
+  React Native entry is unchanged.
+</Callout>
+
 <Callout type="info" title="Use a CSS class for complex responsive styles">
-  React Native Web accepts shared `StyleSheet` values. A web-only modal can also
-  render semantic HTML and use a CSS class when it needs media queries or
+  Inline `style` cannot express a media query. A web-only modal can render
+  semantic HTML and reach for a CSS class when it needs one, or any other
   browser-specific styling.
 </Callout>
 

--- a/apps/docs/content/docs/reference/modal-props.mdx
+++ b/apps/docs/content/docs/reference/modal-props.mdx
@@ -17,12 +17,72 @@ magicModal.show(() => <SettingsModal />, {
 ## Modal options
 
 <auto-type-table
-  path="../../../../../packages/modal/src/constants/types.ts"
+  path="../../../../../packages/modal/src/constants/types.react-native.ts"
   name="NewConfigProps"
 />
 
 `NewConfigProps` is the partial override accepted by `show`. The exported `ModalProps` type is the
 fully resolved internal shape after defaults are applied.
+
+## Container style
+
+`style` is the one option whose type is not the same on every platform, because a React Native style
+and a CSS declaration are not the same thing.
+
+<Tabs groupId="platform" items={["React Native", "Web"]} persist>
+  <Tab value="React Native">
+
+```ts
+style: StyleProp<ViewStyle>;
+```
+
+```tsx
+magicModal.show(() => <SheetModal />, {
+  style: { justifyContent: "flex-end", paddingHorizontal: 16 },
+});
+```
+
+  </Tab>
+  <Tab value="Web">
+
+```ts
+style: React.CSSProperties;
+```
+
+```tsx
+magicModal.show(() => <SheetModal />, {
+  style: { justifyContent: "flex-end", paddingInline: 16 },
+});
+```
+
+  </Tab>
+</Tabs>
+
+<Callout type="warn" title="Breaking change in v10.1 (web only)">
+  The web entry used to type `style` as `StyleProp<ViewStyle>` and let React
+  Native Web translate it at runtime. It is `React.CSSProperties` now, because
+  there is no React Native Web in the browser bundle to translate anything.
+
+Most modals need no change: `justifyContent`, `margin`, `padding`, `backgroundColor` and unitless
+numbers all mean the same thing in both. Four things do change on web:
+
+| Was                                          | Now                                 |
+| -------------------------------------------- | ----------------------------------- |
+| `style: [base, override]`                    | `style: { ...base, ...override }`   |
+| `paddingHorizontal`, `marginVertical`, ...   | `paddingInline`, `marginBlock`, ... |
+| `shadowColor` / `shadowOffset` / `elevation` | `boxShadow`                         |
+| `transform: [{ translateY: 8 }]`             | `transform: "translateY(8px)"`      |
+
+`entering` and `exiting` are gone from the web type as well. They take Reanimated builders, the
+browser bundle has no Reanimated, and they were already documented as ignored there.
+
+A React Native style that slips past TypeScript is not applied on web, and logs one migration
+warning in development.
+
+</Callout>
+
+The React Native entry is unchanged, so a shared config object typed against it needs splitting
+before a web build can use it.
 
 ## Direction
 

--- a/packages/modal/src/components/MagicModalPortal/full-window-overlay.browser.tsx
+++ b/packages/modal/src/components/MagicModalPortal/full-window-overlay.browser.tsx
@@ -3,6 +3,8 @@ import type { ElementType } from "react";
 import { Fragment } from "react";
 
 // FullWindowOverlay only exists to sit above native iOS modal screens. The
-// browser implementation is a fragment, so its bundle has no native overlay
-// dependency.
+// browser implementation is a fragment that is never reached, so its bundle has
+// no native overlay dependency and no Platform check to decide it needs none.
 export const FullWindowOverlay: ElementType = Fragment;
+
+export const isFullWindowOverlaySupported = false;

--- a/packages/modal/src/components/MagicModalPortal/full-window-overlay.tsx
+++ b/packages/modal/src/components/MagicModalPortal/full-window-overlay.tsx
@@ -1,5 +1,7 @@
 import type { ElementType } from "react";
 
+import { Platform } from "react-native";
+
 // A namespace import prevents the package build from rewriting this public
 // entrypoint to a private react-native-screens source path.
 // eslint-disable-next-line import/no-namespace -- see above
@@ -7,3 +9,12 @@ import * as ReactNativeScreens from "react-native-screens";
 
 export const FullWindowOverlay: ElementType =
   ReactNativeScreens.FullWindowOverlay;
+
+/**
+ * react-native-screens' `FullWindowOverlay` is what puts the portal above a
+ * native iOS modal screen. It exists nowhere else.
+ *
+ * The `Platform` check lives here, next to the capability it guards, so the
+ * portal — which the browser shares — does not need one.
+ */
+export const isFullWindowOverlaySupported = Platform.OS === "ios";

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
@@ -11,7 +11,7 @@ import type {
   NewConfigProps,
 } from "../../constants/types";
 
-import type { ComponentType, ElementType } from "react";
+import type { ComponentType, ElementType, ReactNode } from "react";
 
 import React, {
   memo,
@@ -21,7 +21,6 @@ import React, {
   useMemo,
   useRef,
 } from "react";
-import { BackHandler, Platform, StyleSheet, View } from "react-native";
 
 import {
   ANIMATION_DURATION_IN_MS,
@@ -64,6 +63,29 @@ export type ModalStackLeave = (
 
 const dropImmediately: ModalStackLeave = (modals, leaving) =>
   modals.filter((modal) => modal.id !== leaving.id);
+
+/**
+ * The portal's outermost box: full-bleed, transparent to presses, and in or out
+ * of the accessibility tree depending on whether anything is open.
+ *
+ * Injected because it is a `View` on React Native and a `div` on the web, and
+ * because the browser one also carries the chrome's stylesheet.
+ */
+export type PortalContainerProps = {
+  children: ReactNode;
+  hasLiveModals: boolean;
+};
+
+/**
+ * Subscribes to the platform's system back action, returning an unsubscribe.
+ *
+ * Android's hardware back on React Native; nothing at all in a browser, where
+ * the equivalent gesture is Escape and the chrome's focus trap already owns it.
+ * The handler returns true when it consumed the press.
+ */
+export type SystemBackSubscription = (
+  onSystemBack: () => boolean,
+) => () => void;
 
 const getLiveModals = (modals: ModalStackItem[]) =>
   modals.filter((modal) => !modal.isExiting);
@@ -112,16 +134,27 @@ const createModalHandle = <T,>(
  */
 export const createMagicModalPortal = ({
   FullWindowOverlay,
+  isFullWindowOverlaySupported,
+  PortalContainer,
   StackEntry,
   leaveStack = dropImmediately,
+  subscribeToSystemBack,
 }: {
   FullWindowOverlay: ElementType;
   /**
+   * Whether the platform has a full-window overlay at all. True only on iOS,
+   * and injected so this file needs no `Platform` to work that out.
+   */
+  isFullWindowOverlaySupported: boolean;
+  PortalContainer: ComponentType<PortalContainerProps>;
+  /**
    * The platform's modal chrome. Injected rather than imported so the browser
-   * bundle never reaches the Reanimated and gesture-handler one.
+   * bundle never reaches the Reanimated and gesture-handler one, and so this
+   * file — which both platforms share — needs no react-native of its own.
    */
   StackEntry: ComponentType<ModalStackEntryProps>;
   leaveStack?: ModalStackLeave;
+  subscribeToSystemBack: SystemBackSubscription;
 }): React.FC =>
   memo(() => {
     const [modals, setModals] = React.useState<ModalStackItem[]>([]);
@@ -314,38 +347,31 @@ export const createMagicModalPortal = ({
     }, [isOverlayMounted, modals]);
 
     useEffect(() => {
-      if (Platform.OS === "web") {
-        return;
-      }
+      return subscribeToSystemBack(() => {
+        const lastModal = getLiveModals(modals).at(-1);
 
-      const backHandler = BackHandler.addEventListener(
-        "hardwareBackPress",
-        () => {
-          const lastModal = getLiveModals(modals).at(-1);
+        if (!lastModal) {
+          return false;
+        }
 
-          if (!lastModal) {
-            return false;
-          }
+        if (lastModal.config.onBackButtonPress) {
+          lastModal.config.onBackButtonPress({
+            hide: (props) => {
+              _hide(props, { modalID: lastModal.id });
+            },
+          });
+        } else {
+          _hide(
+            { reason: MagicModalHideReason.BACK_BUTTON_PRESS },
+            { modalID: lastModal.id },
+          );
+        }
 
-          if (lastModal.config.onBackButtonPress) {
-            lastModal.config.onBackButtonPress({
-              hide: (props) => {
-                _hide(props, { modalID: lastModal.id });
-              },
-            });
-          } else {
-            _hide(
-              { reason: MagicModalHideReason.BACK_BUTTON_PRESS },
-              { modalID: lastModal.id },
-            );
-          }
-
-          return true;
-        },
-      );
-      return () => {
-        backHandler.remove();
-      };
+        return true;
+      });
+      // `subscribeToSystemBack` closes over `createMagicModalPortal`'s
+      // argument, which is fixed for the lifetime of the component this
+      // returns. It is not a render value, so it is not a dependency.
     }, [_hide, modals]);
 
     const hide = useCallback<GlobalHideFunction>(
@@ -402,7 +428,9 @@ export const createMagicModalPortal = ({
     }, [modals, removeModal]);
 
     const Overlay =
-      fullWindowOverlayEnabled && isOverlayMounted && Platform.OS === "ios"
+      fullWindowOverlayEnabled &&
+      isOverlayMounted &&
+      isFullWindowOverlaySupported
         ? FullWindowOverlay
         : React.Fragment;
 
@@ -415,24 +443,9 @@ export const createMagicModalPortal = ({
      react-navigation modals. Only the overlay wrapper comes and goes. */
     return (
       <Overlay>
-        <View
-          accessibilityElementsHidden={!hasLiveModals}
-          accessibilityViewIsModal={hasLiveModals}
-          aria-hidden={!hasLiveModals}
-          importantForAccessibility={
-            hasLiveModals ? "auto" : "no-hide-descendants"
-          }
-          style={[StyleSheet.absoluteFill, styles.wrapper]}
-          testID="magic-modal-portal"
-        >
+        <PortalContainer hasLiveModals={hasLiveModals}>
           {modalList}
-        </View>
+        </PortalContainer>
       </Overlay>
     );
   });
-
-const styles = StyleSheet.create({
-  wrapper: {
-    pointerEvents: "box-none",
-  },
-});

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal-base.tsx
@@ -132,7 +132,9 @@ const createModalHandle = <T,>(
  * }
  * ```
  */
-export const createMagicModalPortal = ({
+export const createMagicModalPortal = <
+  TConfig extends ModalProps = ModalProps,
+>({
   FullWindowOverlay,
   isFullWindowOverlaySupported,
   PortalContainer,
@@ -152,7 +154,7 @@ export const createMagicModalPortal = ({
    * bundle never reaches the Reanimated and gesture-handler one, and so this
    * file — which both platforms share — needs no react-native of its own.
    */
-  StackEntry: ComponentType<ModalStackEntryProps>;
+  StackEntry: ComponentType<ModalStackEntryProps<TConfig>>;
   leaveStack?: ModalStackLeave;
   subscribeToSystemBack: SystemBackSubscription;
 }): React.FC =>
@@ -412,7 +414,11 @@ export const createMagicModalPortal = ({
           return (
             <MagicModalProvider key={id} hide={hideFunction}>
               <StackEntry
-                config={config}
+                // The stack is platform-agnostic and stores the neutral
+                // `ModalProps`. Which platform's style-typed options are in
+                // there was decided by the entry point that supplied the
+                // chrome, and the chrome is the only thing that reads them.
+                config={config as TConfig}
                 isExiting={Boolean(isExiting)}
                 isTopmost={id === topmostID}
                 onExitFinished={() => {

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal.browser.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal.browser.tsx
@@ -1,8 +1,13 @@
 import type { ModalStackLeave } from "./magic-modal-portal-base";
 
 import { MagicModal } from "../magic-modal.browser";
-import { FullWindowOverlay } from "./full-window-overlay.browser";
+import {
+  FullWindowOverlay,
+  isFullWindowOverlaySupported,
+} from "./full-window-overlay.browser";
 import { createMagicModalPortal } from "./magic-modal-portal-base";
+import { PortalContainer } from "./portal-container.browser";
+import { subscribeToSystemBack } from "./system-back.browser";
 
 /**
  * Keeps a dismissed entry mounted so its exit animation has something to play
@@ -18,12 +23,16 @@ const markExiting: ModalStackLeave = (modals, leaving) =>
   );
 
 /**
- * Browser portal. FullWindowOverlay is a fragment here because it is an
- * iOS-only capability, and the chrome is the Web Animations API one, so
- * nothing in this graph reaches Reanimated, gesture-handler or Worklets.
+ * Browser portal. Every piece the platform decides is the DOM one here: plain
+ * elements for the container, no full-window overlay, no hardware back button,
+ * and the Web Animations API chrome. Nothing in this graph reaches
+ * react-native, react-native-web, Reanimated, gesture-handler or Worklets.
  */
 export const MagicModalPortal = createMagicModalPortal({
   FullWindowOverlay,
+  isFullWindowOverlaySupported,
+  PortalContainer,
   StackEntry: MagicModal,
   leaveStack: markExiting,
+  subscribeToSystemBack,
 });

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal.overlay.test.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal.overlay.test.tsx
@@ -17,6 +17,8 @@ import {
 import { magicModal } from "../../utils/magic-modal-handler";
 import { MagicModal } from "../magic-modal";
 import { createMagicModalPortal } from "./magic-modal-portal-base";
+import { PortalContainer } from "./portal-container";
+import { subscribeToSystemBack } from "./system-back";
 
 /**
  * The iOS FullWindowOverlay is a native window. Left mounted with an empty
@@ -37,17 +39,29 @@ const FullWindowOverlayStub: ElementType = ({
   children?: ReactNode;
 }) => <View testID={OVERLAY_TEST_ID}>{children}</View>;
 
-const TestPortal = createMagicModalPortal({
-  FullWindowOverlay: FullWindowOverlayStub,
-  StackEntry: MagicModal,
-});
+/**
+ * The portal takes every platform decision as an argument, so whether the
+ * platform has a full-window overlay at all is passed in rather than read off
+ * `Platform.OS` at render time. The container and the back-button subscription
+ * are the real React Native ones.
+ */
+const createTestPortal = (isFullWindowOverlaySupported = true) =>
+  createMagicModalPortal({
+    FullWindowOverlay: FullWindowOverlayStub,
+    isFullWindowOverlaySupported,
+    PortalContainer,
+    StackEntry: MagicModal,
+    subscribeToSystemBack,
+  });
+
+const TestPortal = createTestPortal();
 
 const ModalContent = () => <Text testID="overlay-modal">Taveira</Text>;
 
-const render = () =>
+const render = (Portal: React.FC = TestPortal) =>
   rntlRender(
     <GestureHandlerRootView>
-      <TestPortal />
+      <Portal />
     </GestureHandlerRootView>,
   );
 
@@ -202,9 +216,8 @@ describe("MagicModalPortal full window overlay", () => {
     expect(screen.getByTestId("overlay-modal")).toBeTruthy();
   });
 
-  it("never mounts the overlay outside iOS", () => {
-    platform.replaceValue("android");
-    render();
+  it("never mounts the overlay where the platform has no full-window overlay", () => {
+    render(createTestPortal(false));
 
     act(() => {
       magicModal.show(ModalContent);

--- a/packages/modal/src/components/MagicModalPortal/magic-modal-portal.tsx
+++ b/packages/modal/src/components/MagicModalPortal/magic-modal-portal.tsx
@@ -1,6 +1,11 @@
 import { MagicModal } from "../magic-modal";
-import { FullWindowOverlay } from "./full-window-overlay";
+import {
+  FullWindowOverlay,
+  isFullWindowOverlaySupported,
+} from "./full-window-overlay";
 import { createMagicModalPortal } from "./magic-modal-portal-base";
+import { PortalContainer } from "./portal-container";
+import { subscribeToSystemBack } from "./system-back";
 
 /**
  * Portal for the native iOS and Android runtime.
@@ -13,5 +18,8 @@ import { createMagicModalPortal } from "./magic-modal-portal-base";
  */
 export const MagicModalPortal = createMagicModalPortal({
   FullWindowOverlay,
+  isFullWindowOverlaySupported,
+  PortalContainer,
   StackEntry: MagicModal,
+  subscribeToSystemBack,
 });

--- a/packages/modal/src/components/MagicModalPortal/portal-container.browser.tsx
+++ b/packages/modal/src/components/MagicModalPortal/portal-container.browser.tsx
@@ -1,0 +1,35 @@
+import type { PortalContainerProps } from "./magic-modal-portal-base";
+
+import React from "react";
+
+import {
+  classes,
+  MODAL_CLASS,
+  MODAL_STYLESHEET,
+} from "../webModal/modal-styles";
+
+/**
+ * The browser portal container, and the one place the chrome's CSS is emitted.
+ *
+ * The stylesheet is a `<style>` element inside the React tree rather than
+ * something injected into `document.head`, for three reasons: a server render
+ * already contains it, so a modal is never briefly unstyled; nothing has to
+ * touch `document` to install it, so a Next.js server component can import this
+ * module; and there is exactly one portal in an application, so there is
+ * exactly one copy of it.
+ */
+export const PortalContainer = ({
+  children,
+  hasLiveModals,
+}: PortalContainerProps) => (
+  <>
+    <style>{MODAL_STYLESHEET}</style>
+    <div
+      aria-hidden={hasLiveModals ? undefined : true}
+      className={classes(MODAL_CLASS.portal, MODAL_CLASS.boxNone)}
+      data-testid="magic-modal-portal"
+    >
+      {children}
+    </div>
+  </>
+);

--- a/packages/modal/src/components/MagicModalPortal/portal-container.tsx
+++ b/packages/modal/src/components/MagicModalPortal/portal-container.tsx
@@ -1,0 +1,27 @@
+import type { PortalContainerProps } from "./magic-modal-portal-base";
+
+import React from "react";
+import { StyleSheet, View } from "react-native";
+
+/** The React Native portal container: a full-bleed, press-transparent `View`. */
+export const PortalContainer = ({
+  children,
+  hasLiveModals,
+}: PortalContainerProps) => (
+  <View
+    accessibilityElementsHidden={!hasLiveModals}
+    accessibilityViewIsModal={hasLiveModals}
+    aria-hidden={!hasLiveModals}
+    importantForAccessibility={hasLiveModals ? "auto" : "no-hide-descendants"}
+    style={[StyleSheet.absoluteFill, styles.wrapper]}
+    testID="magic-modal-portal"
+  >
+    {children}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  wrapper: {
+    pointerEvents: "box-none",
+  },
+});

--- a/packages/modal/src/components/MagicModalPortal/system-back.browser.ts
+++ b/packages/modal/src/components/MagicModalPortal/system-back.browser.ts
@@ -1,0 +1,8 @@
+import type { SystemBackSubscription } from "./magic-modal-portal-base";
+
+/**
+ * A browser has no hardware back button. Its system dismissal is Escape, which
+ * the chrome's focus trap handles on the topmost dialog, and browser navigation
+ * deliberately does not close a modal.
+ */
+export const subscribeToSystemBack: SystemBackSubscription = () => () => {};

--- a/packages/modal/src/components/MagicModalPortal/system-back.ts
+++ b/packages/modal/src/components/MagicModalPortal/system-back.ts
@@ -1,0 +1,26 @@
+import type { SystemBackSubscription } from "./magic-modal-portal-base";
+
+import { BackHandler, Platform } from "react-native";
+
+/**
+ * Android's hardware back button.
+ *
+ * Nothing subscribes on the web, where `BackHandler` is a stub and the browser
+ * equivalent — Escape — is handled by the modal's focus trap instead. That
+ * check is here rather than in the portal so the browser bundle, which uses
+ * `system-back.browser.ts`, needs no `Platform` to make it.
+ */
+export const subscribeToSystemBack: SystemBackSubscription = (onSystemBack) => {
+  if (Platform.OS === "web") {
+    return () => {};
+  }
+
+  const subscription = BackHandler.addEventListener(
+    "hardwareBackPress",
+    onSystemBack,
+  );
+
+  return () => {
+    subscription.remove();
+  };
+};

--- a/packages/modal/src/components/magic-modal.browser.tsx
+++ b/packages/modal/src/components/magic-modal.browser.tsx
@@ -1,4 +1,5 @@
 import type { ModalStackEntryProps } from "../constants/types";
+import type { ModalProps } from "../constants/types.browser";
 
 import React, {
   memo,
@@ -8,18 +9,18 @@ import React, {
   useMemo,
   useRef,
 } from "react";
-import { Pressable, StyleSheet, useWindowDimensions, View } from "react-native";
 
 import { defaultDirection } from "../constants/default-config";
 import { MagicModalHideReason } from "../constants/types";
 import { useInternalMagicModal } from "./magic-modal-provider";
-import { styles } from "./MagicModalPortal/magic-modal-portal.styles";
 import {
-  getDialogAccessibilityProps,
-  getStackEntryAccessibilityProps,
+  getDialogAriaProps,
+  getStackEntryAriaHidden,
   MODAL_DIALOG_TEST_ID,
   useWebModalFocus,
 } from "./webModal/modal-accessibility";
+import { resolveModalStyle } from "./webModal/modal-style-prop";
+import { classes, MODAL_CLASS } from "./webModal/modal-styles";
 import {
   getContentEnterKeyframes,
   getContentExitKeyframes,
@@ -27,16 +28,22 @@ import {
   runWebAnimation,
 } from "./webModal/modal-transitions";
 import { useSwipeDismiss } from "./webModal/use-swipe-dismiss";
+import { useViewportSize } from "./webModal/use-viewport-size";
 
 /**
  * The browser modal chrome.
  *
- * The same tree, test IDs and accessibility semantics as the React Native
- * chrome in `magic-modal.tsx`, driven by the Web Animations API and Pointer
- * Events instead of Reanimated and gesture-handler. Nothing this file reaches
- * imports react-native-reanimated, react-native-gesture-handler,
- * react-native-worklets or react-native-screens, and
- * `tools/check-web-build.mjs` fails the build if that stops being true.
+ * The same layers, the same test IDs and the same accessibility contract as the
+ * React Native chrome in `magic-modal.tsx`, built out of `div`s, static CSS,
+ * the Web Animations API and Pointer Events.
+ *
+ * Nothing this file reaches imports react-native. That is the point of it:
+ * react-native-web and its style pipeline were 84% of what a web app
+ * downloaded for this library, to render five nested boxes and centre one of
+ * them. `tools/check-web-build.mjs` fails the build if an import creeps back.
+ *
+ * Nothing here touches `document` or `window` at module scope either, so a
+ * Next.js server component can import the package.
  *
  * Unlike the native chrome, this one plays an exit animation. It leans on the
  * portal keeping a dismissed entry in the stack until `onExitFinished` fires.
@@ -46,21 +53,6 @@ import { useSwipeDismiss } from "./webModal/use-swipe-dismiss";
 const useIsomorphicLayoutEffect =
   typeof document === "undefined" ? useEffect : useLayoutEffect;
 
-/**
- * react-native-web hands host refs the DOM node itself but types them as the
- * React Native component. This is the one place that conversion happens.
- */
-const asElement = (node: unknown) => (node ?? null) as HTMLElement | null;
-
-const useElementRef = () => {
-  const ref = useRef<HTMLElement | null>(null);
-  const setRef = useCallback((node: unknown) => {
-    ref.current = asElement(node);
-  }, []);
-
-  return [ref, setRef] as const;
-};
-
 export const MagicModal = memo(
   ({
     config,
@@ -68,21 +60,24 @@ export const MagicModal = memo(
     isExiting,
     isTopmost,
     onExitFinished,
-  }: ModalStackEntryProps) => {
+  }: ModalStackEntryProps<ModalProps>) => {
     const { hide } = useInternalMagicModal();
-    const [dialogNode, setDialogNode] = React.useState<View | null>(null);
+    const [dialogNode, setDialogNode] = React.useState<HTMLDivElement | null>(
+      null,
+    );
     const { onBackButtonPress } = config;
-    const { height, width } = useWindowDimensions();
+    const { height, width } = useViewportSize();
 
-    const [backdropLayerRef, setBackdropLayerRef] = useElementRef();
-    const [backdropRef, setBackdropRef] = useElementRef();
-    const [contentRef, setContentRef] = useElementRef();
-    const [motionRef, setMotionRef] = useElementRef();
+    const backdropLayerRef = useRef<HTMLDivElement | null>(null);
+    const backdropRef = useRef<HTMLDivElement | null>(null);
+    const contentRef = useRef<HTMLDivElement | null>(null);
+    const motionRef = useRef<HTMLDivElement | null>(null);
 
     /** Set once a committed swipe has taken the content off screen. */
     const hasSwipedAwayRef = useRef(false);
 
     const direction = config.swipeDirection ?? defaultDirection;
+    const style = resolveModalStyle(config.style);
 
     const onBackdropPress = useMemo(() => {
       return config.onBackdropPress
@@ -116,7 +111,7 @@ export const MagicModal = memo(
     useSwipeDismiss({
       backdropRef,
       dampingFactor: config.dampingFactor,
-      dialogNode: asElement(dialogNode),
+      dialogNode,
       direction: config.swipeDirection,
       dismissDuration: config.animationOutTiming,
       height,
@@ -150,7 +145,7 @@ export const MagicModal = memo(
           animation.cancel();
         }
       };
-    }, [backdropLayerRef, contentRef]);
+    }, []);
 
     const exitDuration = config.animationOutTiming;
 
@@ -196,76 +191,76 @@ export const MagicModal = memo(
       return () => {
         isCancelled = true;
       };
-    }, [backdropLayerRef, contentRef, exitDuration, isExiting]);
+    }, [exitDuration, isExiting]);
 
     const isBackdropVisible = !config.hideBackdrop;
-    const stackEntryAccessibilityProps =
-      getStackEntryAccessibilityProps(isTopmost);
-    const dialogAccessibilityProps = getDialogAccessibilityProps({
+    const isBackdropPressable = isBackdropVisible && !isExiting;
+    const dialogAriaProps = getDialogAriaProps({
       accessibilityLabel: config.accessibilityLabel,
       isTopmost,
-      onSystemDismiss,
     });
 
     return (
-      <View
-        {...stackEntryAccessibilityProps}
-        style={[StyleSheet.absoluteFill, styles.pointerEventsBoxNone]}
-        testID="magic-modal-stack-entry"
+      <div
+        aria-hidden={getStackEntryAriaHidden(isTopmost)}
+        className={classes(
+          MODAL_CLASS.entry,
+          isTopmost ? MODAL_CLASS.boxNone : MODAL_CLASS.none,
+        )}
+        data-testid="magic-modal-stack-entry"
       >
-        <View
-          pointerEvents={isBackdropVisible && !isExiting ? "auto" : "none"}
-          ref={setBackdropLayerRef}
-          style={styles.backdropContainer}
+        <div
+          className={classes(
+            MODAL_CLASS.backdropLayer,
+            !isBackdropPressable && MODAL_CLASS.none,
+          )}
+          ref={backdropLayerRef}
         >
-          <Pressable
-            accessibilityElementsHidden
-            accessible={false}
+          <div
             aria-hidden
-            disabled={!isBackdropVisible}
-            importantForAccessibility="no-hide-descendants"
-            ref={setBackdropRef}
-            testID="magic-modal-backdrop"
-            style={[
-              styles.backdrop,
-              // eslint-disable-next-line react-native/no-inline-styles, react-native/no-color-literals
-              {
-                backgroundColor: isBackdropVisible
-                  ? config.backdropColor
-                  : "transparent",
-              },
-            ]}
-            onPress={onBackdropPress}
+            className={MODAL_CLASS.backdrop}
+            data-testid="magic-modal-backdrop"
+            ref={backdropRef}
+            role="presentation"
+            // The backdrop colour is configuration, so it cannot live in the
+            // static stylesheet. The two rules below are react-native's, and
+            // this is a `div`.
+            // eslint-disable-next-line react-native/no-inline-styles, react-native/no-color-literals
+            style={{
+              backgroundColor: isBackdropVisible
+                ? config.backdropColor
+                : "transparent",
+            }}
+            // A `div` rather than a `button`: the backdrop is `aria-hidden`,
+            // and a focusable element inside an `aria-hidden` subtree is a trap
+            // for keyboard and screen reader users. Escape is the keyboard's
+            // way out, and it is handled by the focus trap.
+            onClick={isBackdropPressable ? onBackdropPress : undefined}
           />
-        </View>
-        <View
-          pointerEvents="box-none"
-          ref={setMotionRef}
-          style={styles.overlay}
-          testID="magic-modal-motion-layer"
+        </div>
+        <div
+          className={classes(MODAL_CLASS.layer, MODAL_CLASS.boxNone)}
+          data-testid="magic-modal-motion-layer"
+          ref={motionRef}
         >
-          <View
-            pointerEvents="box-none"
-            ref={setContentRef}
-            style={[styles.overlay, config.style]}
-            testID="magic-modal-animation-layer"
+          <div
+            className={classes(MODAL_CLASS.layer, MODAL_CLASS.boxNone)}
+            data-testid="magic-modal-animation-layer"
+            ref={contentRef}
+            style={style}
           >
-            <View
-              {...dialogAccessibilityProps}
-              collapsable={false}
+            <div
+              {...dialogAriaProps}
+              className={classes(MODAL_CLASS.layer, MODAL_CLASS.boxNone)}
+              data-testid={MODAL_DIALOG_TEST_ID}
               ref={setDialogNode}
-              style={[
-                styles.childrenWrapper,
-                config.style,
-                styles.pointerEventsBoxNone,
-              ]}
-              testID={MODAL_DIALOG_TEST_ID}
+              style={style}
             >
               <Children />
-            </View>
-          </View>
-        </View>
-      </View>
+            </div>
+          </div>
+        </div>
+      </div>
     );
   },
 );

--- a/packages/modal/src/components/magic-modal.browser.tsx
+++ b/packages/modal/src/components/magic-modal.browser.tsx
@@ -18,7 +18,7 @@ import {
   getStackEntryAriaHidden,
   MODAL_DIALOG_TEST_ID,
   useWebModalFocus,
-} from "./webModal/modal-accessibility";
+} from "./modal-accessibility";
 import { resolveModalStyle } from "./webModal/modal-style-prop";
 import { classes, MODAL_CLASS } from "./webModal/modal-styles";
 import {

--- a/packages/modal/src/components/magic-modal.browser.web.test.tsx
+++ b/packages/modal/src/components/magic-modal.browser.web.test.tsx
@@ -1,4 +1,7 @@
 import type { HideReturn } from "../constants/types";
+import type { NewConfigProps } from "../constants/types.browser";
+
+import type { CSSProperties } from "react";
 
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -8,8 +11,10 @@ import { magicModal } from "../utils/magic-modal-handler";
 import { MagicModalPortal } from "./MagicModalPortal/magic-modal-portal.browser";
 
 /**
- * The browser chrome, rendered in jsdom with `react-native` aliased to
- * react-native-web — the substitution every web app makes.
+ * The browser chrome, rendered in jsdom.
+ *
+ * There is no react-native-web underneath any more: the chrome renders `div`s
+ * and reads `window`, so jsdom is the whole environment it needs.
  *
  * jsdom has no Web Animations API, so `Element.animate` is faked here with an
  * animation whose `finished` promise this suite resolves by hand. That is the
@@ -76,7 +81,10 @@ const query = (selector: string) => document.querySelectorAll(selector);
 const stackEntries = () =>
   query('[data-testid="magic-modal-stack-entry"]').length;
 
-const dialog = () => document.querySelector('[role="dialog"]');
+const dialog = () => document.querySelector<HTMLElement>('[role="dialog"]');
+
+const byTestID = (testID: string) =>
+  document.querySelector<HTMLElement>(`[data-testid="${testID}"]`);
 
 const render = async () => {
   await act(async () => {
@@ -96,7 +104,7 @@ const ModalContent = () => (
  * from an `async` helper would make the helper adopt it — `await show()` would
  * then hang until something dismissed the modal.
  */
-const show = async (config?: Parameters<typeof magicModal.show>[1]) => {
+const show = async (config?: NewConfigProps) => {
   let handle: Promise<HideReturn<unknown>> | undefined;
 
   await act(async () => {
@@ -112,15 +120,11 @@ beforeAll(() => {
   // jsdom does not implement the Web Animations API at all.
   Element.prototype.animate = fakeAnimate;
 
-  // jsdom lays nothing out, so `document.documentElement` measures 0x0 and
-  // react-native-web's `useWindowDimensions` reports a zero-sized window. The
-  // swipe reads it to work out how far off screen is, so give it a viewport.
-  Object.defineProperty(document.documentElement, "clientHeight", {
-    value: viewport.height,
-  });
-  Object.defineProperty(document.documentElement, "clientWidth", {
-    value: viewport.width,
-  });
+  // The swipe reads the viewport to work out how far off screen is. jsdom's
+  // defaults are already 1024x768; pinning them keeps the arithmetic below
+  // readable and independent of the jsdom version.
+  window.innerHeight = viewport.height;
+  window.innerWidth = viewport.width;
 });
 
 beforeEach(() => {
@@ -146,6 +150,66 @@ describe("browser chrome", () => {
     expect(dialog()?.getAttribute("aria-label")).toBe("Confirm");
     expect(dialog()?.getAttribute("aria-modal")).toBe("true");
     expect(stackEntries()).toBe(1);
+  });
+
+  it("renders plain DOM elements, not react-native-web components", async () => {
+    await render();
+    await show();
+
+    for (const testID of [
+      "magic-modal-portal",
+      "magic-modal-stack-entry",
+      "magic-modal-backdrop",
+      "magic-modal-motion-layer",
+      "magic-modal-animation-layer",
+      "magic-modal-dialog",
+    ]) {
+      expect(byTestID(testID)?.tagName).toBe("DIV");
+    }
+
+    // The layout react-native-web used to compile at runtime, as one static
+    // stylesheet the portal renders. A single copy for the whole application.
+    const stylesheets = [...query("style")].filter(({ textContent }) =>
+      textContent?.includes("magic-modal-box-none"),
+    );
+
+    expect(stylesheets).toHaveLength(1);
+  });
+
+  it("applies the CSS style prop to the modal's own box", async () => {
+    await render();
+    await show({ style: { background: "white", padding: 24 } });
+
+    const dialogStyle = byTestID("magic-modal-dialog")?.style;
+
+    expect(dialogStyle?.background).toBe("white");
+    // React writes a unitless number the way it does everywhere else.
+    expect(dialogStyle?.padding).toBe("24px");
+    expect(byTestID("magic-modal-animation-layer")?.style.padding).toBe("24px");
+  });
+
+  it("warns once about a React Native style instead of applying it", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await render();
+      // The array form TypeScript now rejects, arriving from untyped
+      // JavaScript. It cannot mean anything to a DOM `style` attribute.
+      await show({ style: [{ padding: 10 }] as unknown as CSSProperties });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain("React.CSSProperties");
+      expect(byTestID("magic-modal-dialog")?.getAttribute("style")).toBeNull();
+
+      // Once per process, however many modals repeat the mistake.
+      await show({
+        style: { paddingHorizontal: 10 } as unknown as CSSProperties,
+      });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("plays an entrance built from the direction and the configured timing", async () => {
@@ -317,7 +381,7 @@ describe("swipe-to-dismiss", () => {
     await render();
     await show({ swipeDirection: "left" });
 
-    expect((dialog() as HTMLElement | null)?.style.touchAction).toBe("pan-y");
+    expect(dialog()?.style.touchAction).toBe("pan-y");
   });
 
   it("leaves the browser alone when the swipe is disabled", async () => {
@@ -326,7 +390,7 @@ describe("swipe-to-dismiss", () => {
 
     // jsdom has no `touch-action` in its CSS model, so an untouched property
     // reads back as undefined rather than the empty string a browser gives.
-    expect((dialog() as HTMLElement | null)?.style.touchAction).toBeFalsy();
+    expect(dialog()?.style.touchAction).toBeFalsy();
 
     await flick(dialog()!, { time: 100, y: 300 });
 
@@ -342,12 +406,8 @@ describe("swipe-to-dismiss", () => {
       firePointer(dialog()!, "pointermove", { time: 200, x: 100, y: 400 });
     });
 
-    const motion = document.querySelector<HTMLElement>(
-      '[data-testid="magic-modal-motion-layer"]',
-    );
-    const backdrop = document.querySelector<HTMLElement>(
-      '[data-testid="magic-modal-backdrop"]',
-    );
+    const motion = byTestID("magic-modal-motion-layer");
+    const backdrop = byTestID("magic-modal-backdrop");
 
     expect(motion?.style.transform).toBe("translate3d(0px, 300px, 0)");
     // The backdrop clears in step with the drag: 300px of a 768px screen.
@@ -380,9 +440,7 @@ describe("swipe-to-dismiss", () => {
 
     expect(query('[role="dialog"]')).toHaveLength(1);
 
-    const motion = document.querySelector<HTMLElement>(
-      '[data-testid="magic-modal-motion-layer"]',
-    );
+    const motion = byTestID("magic-modal-motion-layer");
 
     expect(motion?.style.transform).toBe("translate3d(0px, 0px, 0)");
   });
@@ -392,9 +450,7 @@ describe("swipe-to-dismiss", () => {
     await show({ swipeDirection: "down" });
 
     const onClick = jest.fn();
-    const button = document.querySelector<HTMLElement>(
-      '[data-testid="modal-button"]',
-    );
+    const button = byTestID("modal-button");
     button?.addEventListener("click", onClick);
 
     await flick(dialog()!, { time: 2000, y: 300 });

--- a/packages/modal/src/components/magic-modal.tsx
+++ b/packages/modal/src/components/magic-modal.tsx
@@ -6,7 +6,8 @@
  * says to switch it off locally when it misbehaves rather than contort the code.
  */
 
-import type { Direction, ModalChildren, ModalProps } from "../constants/types";
+import type { Direction, ModalChildren } from "../constants/types";
+import type { ModalProps } from "../constants/types.react-native";
 import type { SwipeGestureSpec } from "./panGesture";
 
 import React, { memo, useCallback, useMemo } from "react";
@@ -42,10 +43,12 @@ import { TOUCH_SLOP } from "../constants/gestures";
 import { MagicModalHideReason } from "../constants/types";
 import { useInternalMagicModal } from "./magic-modal-provider";
 import { styles } from "./MagicModalPortal/magic-modal-portal.styles";
-import { PanGestureSurface } from "./panGesture";
 import {
   getDialogAccessibilityProps,
   getStackEntryAccessibilityProps,
+} from "./nativeModal/modal-accessibility";
+import { PanGestureSurface } from "./panGesture";
+import {
   MODAL_DIALOG_TEST_ID,
   useWebModalFocus,
 } from "./webModal/modal-accessibility";
@@ -115,7 +118,10 @@ export const MagicModal = memo(
 
     useWebModalFocus({
       childrenIdentity: Children,
-      dialogNode,
+      // react-native-web hands host refs the DOM node itself but types them as
+      // the React Native component. On a real device this is null-checked
+      // `document` away inside the hook and never dereferenced.
+      dialogNode: dialogNode as unknown as HTMLElement | null,
       isTopmost,
       onSystemDismiss,
     });

--- a/packages/modal/src/components/magic-modal.tsx
+++ b/packages/modal/src/components/magic-modal.tsx
@@ -43,15 +43,12 @@ import { TOUCH_SLOP } from "../constants/gestures";
 import { MagicModalHideReason } from "../constants/types";
 import { useInternalMagicModal } from "./magic-modal-provider";
 import { styles } from "./MagicModalPortal/magic-modal-portal.styles";
+import { MODAL_DIALOG_TEST_ID, useWebModalFocus } from "./modal-accessibility";
 import {
   getDialogAccessibilityProps,
   getStackEntryAccessibilityProps,
 } from "./nativeModal/modal-accessibility";
 import { PanGestureSurface } from "./panGesture";
-import {
-  MODAL_DIALOG_TEST_ID,
-  useWebModalFocus,
-} from "./webModal/modal-accessibility";
 
 export const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 

--- a/packages/modal/src/components/modal-accessibility.ts
+++ b/packages/modal/src/components/modal-accessibility.ts
@@ -1,4 +1,4 @@
-import type { ModalChildren } from "../../constants/types";
+import type { ModalChildren } from "../constants/types";
 
 import { useEffect } from "react";
 

--- a/packages/modal/src/components/nativeModal/modal-accessibility.ts
+++ b/packages/modal/src/components/nativeModal/modal-accessibility.ts
@@ -1,0 +1,57 @@
+import type { ViewProps } from "react-native";
+
+/**
+ * The React Native chrome's accessibility props.
+ *
+ * The same contract the browser chrome states in
+ * `webModal/modal-accessibility.ts`, expressed in React Native props instead of
+ * DOM attributes: `accessibilityElementsHidden` for VoiceOver,
+ * `importantForAccessibility` for TalkBack, `onAccessibilityEscape` for the
+ * iOS two-finger scrub, plus the `aria-*` names react-native-web reads.
+ *
+ * It is not shared with the browser chrome because none of those names mean
+ * anything to a `div`, and passing them to one makes React complain about
+ * unknown attributes.
+ */
+
+export const getStackEntryAccessibilityProps = (
+  isTopmost: boolean,
+): Pick<
+  ViewProps,
+  | "accessibilityElementsHidden"
+  | "aria-hidden"
+  | "importantForAccessibility"
+  | "pointerEvents"
+> => ({
+  accessibilityElementsHidden: !isTopmost,
+  "aria-hidden": !isTopmost,
+  importantForAccessibility: isTopmost ? "auto" : "no-hide-descendants",
+  pointerEvents: isTopmost ? "box-none" : "none",
+});
+
+export const getDialogAccessibilityProps = ({
+  accessibilityLabel,
+  isTopmost,
+  onSystemDismiss,
+}: {
+  accessibilityLabel: string | undefined;
+  isTopmost: boolean;
+  onSystemDismiss: () => void;
+}): Pick<
+  ViewProps,
+  | "accessibilityLabel"
+  | "accessibilityViewIsModal"
+  | "aria-modal"
+  | "importantForAccessibility"
+  | "onAccessibilityEscape"
+  | "role"
+  | "tabIndex"
+> => ({
+  accessibilityLabel: isTopmost ? accessibilityLabel : undefined,
+  accessibilityViewIsModal: isTopmost,
+  "aria-modal": isTopmost ? true : undefined,
+  importantForAccessibility: isTopmost ? "auto" : "no-hide-descendants",
+  onAccessibilityEscape: isTopmost ? onSystemDismiss : undefined,
+  role: isTopmost ? "dialog" : undefined,
+  tabIndex: isTopmost ? -1 : undefined,
+});

--- a/packages/modal/src/components/nativeModal/modal-accessibility.ts
+++ b/packages/modal/src/components/nativeModal/modal-accessibility.ts
@@ -4,7 +4,7 @@ import type { ViewProps } from "react-native";
  * The React Native chrome's accessibility props.
  *
  * The same contract the browser chrome states in
- * `webModal/modal-accessibility.ts`, expressed in React Native props instead of
+ * `modal-accessibility.ts`, expressed in React Native props instead of
  * DOM attributes: `accessibilityElementsHidden` for VoiceOver,
  * `importantForAccessibility` for TalkBack, `onAccessibilityEscape` for the
  * iOS two-finger scrub, plus the `aria-*` names react-native-web reads.

--- a/packages/modal/src/components/webModal/modal-accessibility.ts
+++ b/packages/modal/src/components/webModal/modal-accessibility.ts
@@ -1,7 +1,5 @@
 import type { ModalChildren } from "../../constants/types";
 
-import type { View, ViewProps } from "react-native";
-
 import { useEffect } from "react";
 
 /**
@@ -9,9 +7,12 @@ import { useEffect } from "react";
  *
  * `useWebModalFocus` is a no-op wherever there is no `document`, which is every
  * native runtime. It lives here rather than in either chrome because the
- * browser chrome and the React Native one both need it: react-native-web apps
- * and React Native Web-in-Expo builds reach the DOM through the native chrome
- * too.
+ * browser chrome and the React Native one both need it: a react-native-web app
+ * reaches the DOM through the React Native chrome too.
+ *
+ * Nothing in this file imports react-native, not even for a type. The browser
+ * graph is checked for that, and the React Native chrome's own props are built
+ * next door in `nativeModal/modal-accessibility.ts`.
  */
 
 export const MODAL_DIALOG_TEST_ID = "magic-modal-dialog";
@@ -40,47 +41,33 @@ const focusFirstElement = (dialog: HTMLElement) => {
   target.focus();
 };
 
-export const getStackEntryAccessibilityProps = (
-  isTopmost: boolean,
-): Pick<
-  ViewProps,
-  | "accessibilityElementsHidden"
-  | "aria-hidden"
-  | "importantForAccessibility"
-  | "pointerEvents"
-> => ({
-  accessibilityElementsHidden: !isTopmost,
-  "aria-hidden": !isTopmost,
-  importantForAccessibility: isTopmost ? "auto" : "no-hide-descendants",
-  pointerEvents: isTopmost ? "box-none" : "none",
-});
-
-export const getDialogAccessibilityProps = ({
+/**
+ * The dialog's ARIA attributes, for a chrome that renders DOM elements.
+ *
+ * Only the topmost entry is a dialog. The ones under it keep their DOM nodes —
+ * dropping them would unmount their content — and give up every attribute that
+ * would put them in the accessibility tree.
+ *
+ * `undefined` rather than `false` throughout, because React omits an undefined
+ * attribute where `aria-modal={false}` would render `aria-modal="false"` and
+ * announce a second, non-modal dialog.
+ */
+export const getDialogAriaProps = ({
   accessibilityLabel,
   isTopmost,
-  onSystemDismiss,
 }: {
   accessibilityLabel: string | undefined;
   isTopmost: boolean;
-  onSystemDismiss: () => void;
-}): Pick<
-  ViewProps,
-  | "accessibilityLabel"
-  | "accessibilityViewIsModal"
-  | "aria-modal"
-  | "importantForAccessibility"
-  | "onAccessibilityEscape"
-  | "role"
-  | "tabIndex"
-> => ({
-  accessibilityLabel: isTopmost ? accessibilityLabel : undefined,
-  accessibilityViewIsModal: isTopmost,
+}) => ({
+  "aria-label": isTopmost ? accessibilityLabel : undefined,
   "aria-modal": isTopmost ? true : undefined,
-  importantForAccessibility: isTopmost ? "auto" : "no-hide-descendants",
-  onAccessibilityEscape: isTopmost ? onSystemDismiss : undefined,
   role: isTopmost ? "dialog" : undefined,
   tabIndex: isTopmost ? -1 : undefined,
 });
+
+/** `aria-hidden` for a stack entry: set on every entry below the top one. */
+export const getStackEntryAriaHidden = (isTopmost: boolean) =>
+  isTopmost ? undefined : true;
 
 export const useWebModalFocus = ({
   childrenIdentity,
@@ -89,7 +76,7 @@ export const useWebModalFocus = ({
   onSystemDismiss,
 }: {
   childrenIdentity: ModalChildren;
-  dialogNode: View | null;
+  dialogNode: HTMLElement | null;
   isTopmost: boolean;
   onSystemDismiss: () => void;
 }) => {
@@ -98,7 +85,7 @@ export const useWebModalFocus = ({
       return;
     }
 
-    const dialog = dialogNode as unknown as HTMLElement | null;
+    const dialog = dialogNode;
     const focusToRestore =
       document.activeElement instanceof HTMLElement
         ? document.activeElement
@@ -147,7 +134,7 @@ export const useWebModalFocus = ({
       return;
     }
 
-    const dialog = dialogNode as unknown as HTMLElement | null;
+    const dialog = dialogNode;
 
     if (!dialog) {
       return;

--- a/packages/modal/src/components/webModal/modal-style-prop.ts
+++ b/packages/modal/src/components/webModal/modal-style-prop.ts
@@ -1,0 +1,92 @@
+import type { CSSProperties } from "react";
+
+/**
+ * `config.style` on the browser entry, and what to do with the old React Native
+ * shape when someone passes it anyway.
+ *
+ * v10.1 changed this prop's type from `StyleProp<ViewStyle>` to
+ * `React.CSSProperties`. The two overlap enough that most modals migrate by
+ * changing nothing, and differ enough that the ones that do not would fail
+ * silently: an array reaches the DOM as `style={["0", "1"]}` and a
+ * `paddingHorizontal` is simply dropped, both without a word.
+ *
+ * TypeScript catches this at the call site. The check below is for the callers
+ * TypeScript cannot see — untyped JavaScript, a config assembled from
+ * `Record<string, unknown>`, a shared config object typed against the React
+ * Native entry.
+ */
+
+/**
+ * React Native style keys with no CSS equivalent of the same name. Not
+ * exhaustive: enough of the common ones to name the problem when one appears.
+ */
+const REACT_NATIVE_ONLY_KEYS = [
+  "elevation",
+  "includeFontPadding",
+  "marginHorizontal",
+  "marginVertical",
+  "paddingHorizontal",
+  "paddingVertical",
+  "resizeMode",
+  "shadowColor",
+  "shadowOffset",
+  "shadowOpacity",
+  "shadowRadius",
+  "textAlignVertical",
+  "tintColor",
+];
+
+const MIGRATION_HINT = `[magic-modal] The web entry's \`style\` is React.CSSProperties as of v10.1, not a React Native style.
+
+Pass one plain CSS object: no arrays, no StyleSheet handles, and CSS property names.
+  paddingHorizontal: 16  ->  paddingInline: 16
+  marginVertical: 8      ->  marginBlock: 8
+  shadow* / elevation    ->  boxShadow
+  [a, b]                 ->  { ...a, ...b }
+
+React Native styles keep working on the React Native entry, which still types this as StyleProp<ViewStyle>.`;
+
+/** Once per process: the same modal config usually renders many times. */
+let hasWarned = false;
+
+const looksLikeReactNativeStyle = (style: unknown) => {
+  if (Array.isArray(style)) {
+    return true;
+  }
+
+  if (typeof style !== "object" || style === null) {
+    // A registered `StyleSheet.create` handle used to be a number.
+    return typeof style === "number";
+  }
+
+  const record = style as Record<string, unknown>;
+
+  return (
+    Array.isArray(record.transform) ||
+    REACT_NATIVE_ONLY_KEYS.some((key) => record[key] !== undefined)
+  );
+};
+
+/**
+ * Narrows `config.style` to what the DOM can take, and says so in development
+ * when it had to drop something.
+ *
+ * An array is dropped rather than flattened. Flattening it would be guessing at
+ * what the caller meant on a prop whose type says arrays are gone, and would
+ * turn a loud break into a subtly wrong one.
+ */
+export const resolveModalStyle = (
+  style: unknown,
+): CSSProperties | undefined => {
+  if (__DEV__ && !hasWarned && looksLikeReactNativeStyle(style)) {
+    hasWarned = true;
+    // eslint-disable-next-line no-console
+    console.warn(MIGRATION_HINT);
+  }
+
+  if (typeof style !== "object" || style === null || Array.isArray(style)) {
+    return undefined;
+  }
+
+  return style as CSSProperties;
+};

--- a/packages/modal/src/components/webModal/modal-styles.ts
+++ b/packages/modal/src/components/webModal/modal-styles.ts
@@ -1,0 +1,102 @@
+/**
+ * The browser chrome's layout, as static CSS.
+ *
+ * This replaces `StyleSheet.create` and react-native-web's style pipeline. That
+ * pipeline — the StyleSheet compiler, styleq, inline-style-prefixer,
+ * normalize-colors and the React Native-to-DOM prop translation around them —
+ * was over half of what a web app downloaded for this library, to produce a
+ * handful of rules that never change.
+ *
+ * The rules are a faithful copy of what react-native-web compiled the old
+ * `StyleSheet` to, including the parts of its `View` reset that a page's own
+ * CSS could otherwise break: a consumer with `div { padding: 8px }` used to get
+ * the same layout as everyone else and still has to.
+ *
+ * `MODAL_STYLESHEET` is a constant string rendered inside a `<style>` element
+ * by the portal, not injected into `document.head`. Nothing here touches the
+ * DOM at module scope, so a Next.js server component can import this file, and
+ * the CSS is already in the server-rendered HTML — there is no frame where the
+ * modal is unstyled.
+ */
+
+export const MODAL_CLASS = {
+  /** The portal's own box: one per application, around the whole stack. */
+  portal: "magic-modal-portal",
+  /** The full-bleed, click-through wrapper around one stack entry. */
+  entry: "magic-modal-entry",
+  /** The layer that fades, and that owns the backdrop's press target. */
+  backdropLayer: "magic-modal-backdrop-layer",
+  backdrop: "magic-modal-backdrop",
+  /** Motion, content and dialog layers: `flex: 1`, vertically centred. */
+  layer: "magic-modal-layer",
+  /** `pointerEvents: "box-none"`: transparent to presses, children are not. */
+  boxNone: "magic-modal-box-none",
+  /** `pointerEvents: "none"`: transparent to presses, children included. */
+  none: "magic-modal-none",
+} as const;
+
+/**
+ * react-native-web's `View` reset, minus the parts nothing here relies on.
+ *
+ * `box-sizing`, the zeroed box and `position: relative` are the ones that
+ * matter: they are what make a `View` behave the same inside any page.
+ */
+const VIEW_RESET = `align-items: stretch;
+  border: 0 solid;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  min-height: 0;
+  min-width: 0;
+  padding: 0;
+  position: relative;
+  z-index: 0;`;
+
+/**
+ * `pointer-events` carries `!important` because react-native-web's compiler
+ * emitted it that way, and the modal depends on the result: the layers between
+ * the backdrop and the content have to stay transparent to presses even when a
+ * consumer's own CSS has an opinion about `pointer-events` on a descendant.
+ */
+export const MODAL_STYLESHEET = `.${MODAL_CLASS.portal},
+.${MODAL_CLASS.entry},
+.${MODAL_CLASS.backdropLayer},
+.${MODAL_CLASS.backdrop},
+.${MODAL_CLASS.layer} {
+  ${VIEW_RESET}
+}
+
+.${MODAL_CLASS.portal},
+.${MODAL_CLASS.entry},
+.${MODAL_CLASS.backdropLayer} {
+  inset: 0;
+  position: absolute;
+}
+
+.${MODAL_CLASS.backdrop},
+.${MODAL_CLASS.layer} {
+  flex: 1 1 0%;
+}
+
+.${MODAL_CLASS.layer} {
+  justify-content: center;
+}
+
+.${MODAL_CLASS.boxNone},
+.${MODAL_CLASS.none} {
+  pointer-events: none !important;
+}
+
+.${MODAL_CLASS.boxNone} > * {
+  pointer-events: auto;
+}
+
+.${MODAL_CLASS.none} > * {
+  pointer-events: none;
+}
+`;
+
+/** Joins class names, skipping the ones a conditional turned off. */
+export const classes = (...names: (string | false | undefined)[]) =>
+  names.filter(Boolean).join(" ");

--- a/packages/modal/src/components/webModal/use-viewport-size.ts
+++ b/packages/modal/src/components/webModal/use-viewport-size.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+/**
+ * The viewport, in CSS pixels, standing in for `useWindowDimensions`.
+ *
+ * The swipe reads it to work out how far off screen is, which is the only thing
+ * the chrome ever needed react-native-web's `Dimensions` for.
+ *
+ * `visualViewport` is the size actually on screen, so a modal dragged away on a
+ * phone with the software keyboard open, or on a pinch-zoomed page, travels the
+ * distance the user can see rather than the layout distance. It is read first
+ * for that reason and falls back to `window.inner*` where it is missing.
+ */
+
+const EMPTY_VIEWPORT = { height: 0, width: 0 };
+
+const readViewport = () => {
+  if (typeof window === "undefined") {
+    return EMPTY_VIEWPORT;
+  }
+
+  const visual = window.visualViewport;
+
+  return {
+    height: visual?.height ?? window.innerHeight,
+    width: visual?.width ?? window.innerWidth,
+  };
+};
+
+export const useViewportSize = () => {
+  // The initializer runs on the server too, where it returns zeroes rather
+  // than reaching for a `window` that is not there. Nothing is rendered from
+  // this, so a server and a client first render still agree.
+  const [size, setSize] = useState(readViewport);
+
+  useEffect(() => {
+    const update = () => {
+      const next = readViewport();
+
+      setSize((previous) =>
+        previous.height === next.height && previous.width === next.width
+          ? previous
+          : next,
+      );
+    };
+
+    // Mounting after a resize, or after hydrating from a server render, both
+    // land here with a stale size.
+    update();
+
+    const visual = window.visualViewport;
+
+    window.addEventListener("resize", update);
+    visual?.addEventListener("resize", update);
+    visual?.addEventListener("scroll", update);
+
+    return () => {
+      window.removeEventListener("resize", update);
+      visual?.removeEventListener("resize", update);
+      visual?.removeEventListener("scroll", update);
+    };
+  }, []);
+
+  return size;
+};

--- a/packages/modal/src/constants/types.browser.ts
+++ b/packages/modal/src/constants/types.browser.ts
@@ -1,0 +1,43 @@
+import type { ModalConfigCommon } from "./types";
+
+import type { CSSProperties } from "react";
+
+/**
+ * The browser entry's modal options.
+ *
+ * Everything platform-neutral comes from {@link ModalConfigCommon}. `style` is
+ * the only addition, and it is CSS, because the browser chrome renders plain
+ * DOM elements and hands this straight to a `style` attribute. There is no
+ * react-native-web underneath to translate React Native styles any more.
+ *
+ * The Reanimated `entering` and `exiting` builders are not here. They never did
+ * anything on the web, and there is no Reanimated in this bundle to build one
+ * with.
+ */
+export type ModalProps = ModalConfigCommon & {
+  /**
+   * Custom CSS for the modal container.
+   *
+   * Applied as an inline `style` attribute on the modal's own layout box, so
+   * anything the browser accepts works: `position: "fixed"`, `gridTemplate`,
+   * `inset`, custom properties.
+   *
+   * **Breaking change in v10.1.** This used to be `StyleProp<ViewStyle>`, the
+   * React Native style type, which react-native-web translated at runtime.
+   * React Native style objects are not CSS and are no longer accepted:
+   * - style arrays: pass one object, or spread them yourself.
+   * - React Native-only shorthands: `paddingHorizontal: 16` becomes
+   *   `paddingInline: 16` (or `padding: "0 16px"`), `marginVertical`,
+   *   `shadow*` and `elevation` become `boxShadow`.
+   * - unitless numbers still work, exactly as they do in React: `padding: 10`
+   *   is `10px`.
+   *
+   * The React Native entry still types this as `StyleProp<ViewStyle>`.
+   * @default {}
+   * @example { background: "white", borderRadius: 20, padding: 24 }
+   */
+  style: CSSProperties;
+};
+
+/** Per-modal overrides accepted by `magicModal.show` in the browser. */
+export type NewConfigProps = Partial<ModalProps>;

--- a/packages/modal/src/constants/types.react-native.ts
+++ b/packages/modal/src/constants/types.react-native.ts
@@ -1,0 +1,49 @@
+import type { ModalConfigCommon } from "./types";
+import type Animated from "react-native-reanimated";
+
+import type { StyleProp, ViewStyle } from "react-native";
+
+/**
+ * The React Native entry's modal options.
+ *
+ * Everything platform-neutral comes from {@link ModalConfigCommon}. What is
+ * added here is what only React Native can express: a `StyleProp<ViewStyle>`
+ * and the two Reanimated builders. The browser entry declares the same three
+ * names in `types.browser.ts` with web types, and each entry point ships its
+ * own `.d.ts`, so an app only ever sees the one for the platform it resolved.
+ */
+export type ModalProps = ModalConfigCommon & {
+  /**
+   * Custom React Native style for the animated modal container.
+   *
+   * The browser entry types this as `React.CSSProperties` instead. See
+   * {@link https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs the web guide}.
+   * @default {}
+   * @example { backgroundColor: 'red', padding: 10 }
+   */
+  style: StyleProp<ViewStyle>;
+
+  /**
+   * Reanimated entering animation for the modal content.
+   *
+   * React Native only. The browser entry has no Reanimated in it, so it plays
+   * its own CSS-timed entrance built from `swipeDirection` and
+   * `animationInTiming`, and does not accept this prop at all.
+   * @default undefined
+   * @platform ios, android
+   */
+  entering?: React.ComponentProps<typeof Animated.View>["entering"];
+
+  /**
+   * Reanimated exiting animation for the modal content.
+   *
+   * React Native only, and only on iOS and Android for the same reason as
+   * {@link ModalProps.entering}.
+   * @default undefined
+   * @platform ios, android
+   */
+  exiting?: React.ComponentProps<typeof Animated.View>["exiting"];
+};
+
+/** Per-modal overrides accepted by `magicModal.show` on React Native. */
+export type NewConfigProps = Partial<ModalProps>;

--- a/packages/modal/src/constants/types.ts
+++ b/packages/modal/src/constants/types.ts
@@ -1,7 +1,3 @@
-import type Animated from "react-native-reanimated";
-
-import type { StyleProp, ViewStyle } from "react-native";
-
 /** A component factory rendered as the body of a modal stack entry. */
 export type ModalChildren = React.FC;
 
@@ -25,7 +21,17 @@ export type HideReturn<T> =
     }
   | { reason: MagicModalHideReason.INTENTIONAL_HIDE; data: T };
 
-export type ModalProps = {
+/**
+ * Every modal option whose type is the same on every platform.
+ *
+ * The style-typed options are not here, because they are not the same: the
+ * React Native entry types `style` as `StyleProp<ViewStyle>` and takes
+ * Reanimated `entering`/`exiting` builders, while the browser entry types
+ * `style` as `React.CSSProperties` and has no Reanimated to build from. Each
+ * entry point declares its own `ModalProps` on top of this — see
+ * `types.react-native.ts` and `types.browser.ts`.
+ */
+export type ModalConfigCommon = {
   /**
    * Accessible name announced for the modal container.
    *
@@ -81,13 +87,6 @@ export type ModalProps = {
   onBackdropPress: (({ hide }: { hide: HookHideFunction }) => void) | undefined;
 
   /**
-   * Custom React Native style for the animated modal container.
-   * @default {}
-   * @example { backgroundColor: 'red', padding: 10 }
-   */
-  style: StyleProp<ViewStyle>;
-
-  /**
    * Damping factor for the swipe gesture.
    * @default 0.2
    */
@@ -106,39 +105,33 @@ export type ModalProps = {
    * @default 500
    */
   swipeVelocityThreshold: number;
-} & {
-  /**
-   * Reanimated entering animation for the modal content.
-   *
-   * React Native only. The browser entry has no Reanimated in it, so it plays
-   * its own CSS-timed entrance built from `swipeDirection` and
-   * `animationInTiming` and ignores this.
-   * @default undefined
-   * @platform ios, android
-   */
-  entering?: React.ComponentProps<typeof Animated.View>["entering"];
+};
 
-  /**
-   * Reanimated exiting animation for the modal content.
-   *
-   * React Native only, and only on iOS and Android for the same reason as
-   * {@link ModalProps.entering}.
-   * @default undefined
-   * @platform ios, android
-   */
-  exiting?: React.ComponentProps<typeof Animated.View>["exiting"];
+/**
+ * The config the portal, the handler and the stack move around.
+ *
+ * Deliberately not the public `ModalProps`: nothing between `magicModal.show`
+ * and the platform's chrome reads a style-typed option, so nothing in between
+ * needs to know which platform's types are in play. The chrome that does read
+ * them narrows this to its own entry's `ModalProps`.
+ */
+export type ModalProps = ModalConfigCommon & {
+  style?: unknown;
+  entering?: unknown;
+  exiting?: unknown;
 };
 
 /**
  * What the portal hands each entry in the modal stack.
  *
- * `magic-modal.tsx` and `magic-modal.browser.tsx` both satisfy this; the portal
- * is handed whichever one the platform's entry point pulled in. The last two
- * fields only ever move on the browser chrome — see `createMagicModalPortal`.
+ * `magic-modal.tsx` and `magic-modal.browser.tsx` both satisfy this, each with
+ * its own `TConfig`; the portal is handed whichever one the platform's entry
+ * point pulled in. The last two fields only ever move on the browser chrome —
+ * see `createMagicModalPortal`.
  */
-export type ModalStackEntryProps = {
+export type ModalStackEntryProps<TConfig extends ModalProps = ModalProps> = {
   children: ModalChildren;
-  config: ModalProps;
+  config: TConfig;
   /** True while the entry is dismissed but still playing its exit animation. */
   isExiting: boolean;
   isTopmost: boolean;
@@ -172,7 +165,12 @@ export type DisableFullWindowOverlayFunction = () => void;
 
 export type HookHideFunction = <T>(props: HideReturn<T>) => void;
 
-/** Per-modal overrides accepted by `magicModal.show`. */
+/**
+ * Per-modal overrides accepted by `magicModal.show`.
+ *
+ * The exported one is per entry point, because {@link ModalProps} is. This is
+ * the internal, platform-agnostic shape.
+ */
 export type NewConfigProps = Partial<ModalProps>;
 
 /** Explains why a modal promise resolved. */

--- a/packages/modal/src/index.react-native.ts
+++ b/packages/modal/src/index.react-native.ts
@@ -1,12 +1,25 @@
+import type { ModalProps } from "./constants/types.react-native";
+import type { MagicModalAPI } from "./utils/magic-modal-handler";
+
+import { magicModal as magicModalCore } from "./utils/magic-modal-handler";
+
 export { MagicModalPortal } from "./components/MagicModalPortal/magic-modal-portal";
 export {
   MagicModalHideReason,
   type HideReturn,
-  type NewConfigProps,
   type ModalChildren,
   type ModalHandle,
   type Direction,
-  type ModalProps,
 } from "./constants/types";
-export { magicModal } from "./utils/magic-modal-handler";
+export type {
+  ModalProps,
+  NewConfigProps,
+} from "./constants/types.react-native";
 export { useMagicModal } from "./components/magic-modal-provider";
+
+/**
+ * The imperative modal API, typed for React Native: `style` is a
+ * `StyleProp<ViewStyle>`, and {@link ModalProps.entering} and
+ * {@link ModalProps.exiting} take Reanimated builders.
+ */
+export const magicModal: MagicModalAPI<ModalProps> = magicModalCore;

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -1,12 +1,25 @@
+import type { ModalProps } from "./constants/types.browser";
+import type { MagicModalAPI } from "./utils/magic-modal-handler";
+
+import { magicModal as magicModalCore } from "./utils/magic-modal-handler";
+
 export { MagicModalPortal } from "./components/MagicModalPortal/magic-modal-portal.browser";
 export {
   MagicModalHideReason,
   type HideReturn,
-  type NewConfigProps,
   type ModalChildren,
   type ModalHandle,
   type Direction,
-  type ModalProps,
 } from "./constants/types";
-export { magicModal } from "./utils/magic-modal-handler";
+export type { ModalProps, NewConfigProps } from "./constants/types.browser";
 export { useMagicModal } from "./components/magic-modal-provider";
+
+/**
+ * The imperative modal API.
+ *
+ * Identical to the React Native entry's, except for the style-typed options in
+ * {@link ModalProps}: `style` is `React.CSSProperties` here, and the Reanimated
+ * `entering` and `exiting` builders are not accepted at all, because there is
+ * no Reanimated in this bundle to build one with.
+ */
+export const magicModal: MagicModalAPI<ModalProps> = magicModalCore;

--- a/packages/modal/src/utils/magic-modal-handler.ts
+++ b/packages/modal/src/utils/magic-modal-handler.ts
@@ -4,16 +4,17 @@ import type {
   GlobalHideAllFunction,
   GlobalHideFunction,
   GlobalShowFunction,
+  ModalChildren,
+  ModalHandle,
+  ModalProps,
 } from "../constants/types";
 
 import React from "react";
 
 import {
-  // HideReturn and ModalHandle are used in JS Doc
+  // HideReturn is used in JS Doc
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   HideReturn,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ModalHandle,
 } from "../constants/types";
 
 export const magicModalRef = React.createRef<IModal>();
@@ -54,6 +55,26 @@ export type IModal = {
   hideAll: typeof hideAll;
   enableFullWindowOverlay: typeof enableFullWindowOverlay;
   disableFullWindowOverlay: typeof disableFullWindowOverlay;
+};
+
+/**
+ * The `magicModal` object, with `show` typed against one platform's config.
+ *
+ * There is one runtime object and one stack. What differs between the entry
+ * points is the type of the style-typed options `show` accepts:
+ * `StyleProp<ViewStyle>` on React Native, `React.CSSProperties` in the browser.
+ * Each `index.*.ts` re-exports the same object under this type with its own
+ * `ModalProps`, and each ships its own `.d.ts`, so an application only ever
+ * sees the one it resolved.
+ */
+export type MagicModalAPI<TConfig extends ModalProps> = Omit<
+  typeof magicModal,
+  "show"
+> & {
+  show: <T>(
+    newComponent: ModalChildren,
+    newConfig?: Partial<TConfig>,
+  ) => ModalHandle<T>;
 };
 
 /**

--- a/packages/modal/src/web-bundle.test.ts
+++ b/packages/modal/src/web-bundle.test.ts
@@ -48,10 +48,15 @@ const nativeOutputs = [
 ];
 
 /**
- * The packages the browser entry exists to avoid. Reanimated, gesture-handler
- * and Worklets were 62% of the web bundle before it grew its own chrome.
+ * The packages the browser entry exists to avoid.
+ *
+ * Reanimated, gesture-handler and Worklets were 62% of the web bundle before it
+ * grew its own chrome; react-native-web and its style pipeline were 84% of what
+ * was left. A web-only application installs none of them.
  */
 const nativeOnlyPackages = [
+  "react-native",
+  "react-native-web",
   "react-native-gesture-handler",
   "react-native-reanimated",
   "react-native-screens",
@@ -59,7 +64,7 @@ const nativeOnlyPackages = [
 ];
 
 describe("built browser entry", () => {
-  it.each(browserOutputs)("keeps native-only packages out of %s", (file) => {
+  it.each(browserOutputs)("keeps React Native packages out of %s", (file) => {
     const output = readDist(file);
 
     for (const packageName of nativeOnlyPackages) {
@@ -73,30 +78,46 @@ describe("built browser entry", () => {
     }
   });
 
-  it.each(browserOutputs)("ships the Web Animations chrome in %s", (file) => {
+  it.each(browserOutputs)("ships the DOM chrome in %s", (file) => {
     const output = readDist(file);
+    // Comments go first: several of them name the very things being asserted
+    // absent, because they explain why those things are gone.
+    const code = stripComments(output);
 
     // The browser chrome drives motion by hand rather than through Reanimated's
     // animated components, so neither helper can be in here.
-    expect(output).not.toContain("createAnimatedComponent");
-    expect(output).not.toContain("useAnimatedStyle");
+    expect(code).not.toContain("createAnimatedComponent");
+    expect(code).not.toContain("useAnimatedStyle");
+    // Nor lay out through react-native-web's style pipeline, which is what a
+    // `StyleSheet.create` call would reach.
+    expect(code).not.toContain("StyleSheet.create");
     // The tree itself is unchanged, which is what keeps the test IDs and the
     // accessibility contract identical across platforms.
-    expect(output).toContain("magic-modal-motion-layer");
-    expect(output).toContain("magic-modal-animation-layer");
+    expect(code).toContain("magic-modal-motion-layer");
+    expect(code).toContain("magic-modal-animation-layer");
+    // The layout react-native-web used to compile, shipped as static CSS.
+    expect(code).toContain("magic-modal-box-none");
   });
 
-  it("only reaches react-native, which a web bundler aliases", () => {
+  it("reaches nothing but react", () => {
     const imported = [
       ...stripComments(readDist("index.runtime.js")).matchAll(
         /from\s*['"]([^'".][^'"]*)['"]/g,
       ),
     ].map(([, specifier]) => specifier);
 
-    expect([...new Set(imported)].sort()).toStrictEqual([
-      "react",
-      "react-native",
-    ]);
+    expect([...new Set(imported)].sort()).toStrictEqual(["react"]);
+  });
+
+  it("declares the web style prop as CSS, not a React Native style", () => {
+    const types = readDist("index.d.ts");
+
+    expect(types).toContain("style: CSSProperties");
+    expect(types).not.toContain("StyleProp<ViewStyle>;");
+    // A web consumer has no react-native types installed, so the browser
+    // declaration file cannot reference any.
+    expect(importsPackage(types, "react-native")).toBe(false);
+    expect(importsPackage(types, "react-native-reanimated")).toBe(false);
   });
 });
 
@@ -115,4 +136,11 @@ describe("built React Native entry", () => {
       expect(readDist(file)).not.toContain("react-native-screens/src/");
     },
   );
+
+  it("keeps the React Native style prop", () => {
+    const types = readDist("index.react-native.d.ts");
+
+    expect(types).toContain("style: StyleProp<ViewStyle>");
+    expect(types).not.toContain("style: CSSProperties");
+  });
 });

--- a/packages/modal/tools/check-web-build.mjs
+++ b/packages/modal/tools/check-web-build.mjs
@@ -10,14 +10,21 @@ const browserOutputFiles = ["dist/index.runtime.js", "dist/index.runtime.cjs"];
 const privateScreensImport = "react-native-screens/src/";
 
 /**
- * Every native-only package the browser entry has to stay clear of.
+ * Every React Native package the browser entry has to stay clear of.
  *
- * The three animation and gesture packages are the expensive ones: together
- * they were 62% of what a web app downloaded for this library before the
+ * `react-native` itself is on the list as of v10.1. The browser chrome renders
+ * plain DOM elements, so a web app needs neither react-native nor
+ * react-native-web installed, and neither one is 84% of its download any more.
+ * The animation and gesture packages went in the release before, when the
  * browser chrome grew its own Web Animations API and Pointer Events
- * implementation. Screens has been out since the portal split.
+ * implementation.
+ *
+ * `react-native` matching is anchored on the quote that follows it, so
+ * `react-native-magic-modal` in a doc example is not a hit.
  */
 const nativeOnlyPackages = [
+  "react-native",
+  "react-native-web",
   "react-native-gesture-handler",
   "react-native-reanimated",
   "react-native-screens",
@@ -26,12 +33,12 @@ const nativeOnlyPackages = [
 
 /**
  * The gzipped ceiling for what a web app downloads, measured the way
- * `measure-web-bundle.mjs` measures it. Set roughly 20% above the real number,
- * so ordinary changes pass and anything that drags a native package back in
- * fails loudly. Re-run `node tools/measure-web-bundle.mjs` and move it
+ * `measure-web-bundle.mjs` measures it. Set roughly 25% above the real number,
+ * so ordinary changes pass and anything that drags a React Native package back
+ * in fails loudly. Re-run `node tools/measure-web-bundle.mjs` and move it
  * deliberately.
  */
-const gzipBudgetInBytes = 40_000;
+const gzipBudgetInBytes = 6_800;
 const packageJSON = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), {
     encoding: "utf8",
@@ -114,7 +121,7 @@ for (const { output, outputFile } of browserOutputs) {
 
     if (reference.test(code)) {
       throw new Error(
-        `${outputFile} imports ${packageName}, which is native-only. The browser chrome in src/components/magic-modal.browser.tsx exists so the web entry never needs it.`,
+        `${outputFile} imports ${packageName}, which is React Native only. The browser chrome in src/components/magic-modal.browser.tsx renders DOM elements so the web entry never needs it.`,
       );
     }
   }
@@ -124,8 +131,18 @@ for (const { output, outputFile } of browserOutputs) {
 // browser entry the way a web bundler does catches the rest: a package pulled in
 // through a re-export, a `.web.js` variant, or anything else that arrives
 // without its name appearing in the output.
+//
+// Measured twice. With the `react-native` -> `react-native-web` alias, because
+// that is what a react-native-web app configures and the number has to hold
+// there. Without it, because a web-only app has neither package installed, and
+// a bundle that only stays small because an alias redirected something is not
+// actually independent of it.
 const { gzip, metafile, minified } = await measureWebBundle();
-const resolvedInputs = Object.keys(metafile.inputs);
+const withoutAlias = await measureWebBundle({ withReactNativeAlias: false });
+const resolvedInputs = [
+  ...Object.keys(metafile.inputs),
+  ...Object.keys(withoutAlias.metafile.inputs),
+];
 
 for (const packageName of nativeOnlyPackages) {
   const pulledIn = resolvedInputs.find((input) =>
@@ -134,14 +151,45 @@ for (const packageName of nativeOnlyPackages) {
 
   if (pulledIn) {
     throw new Error(
-      `Bundling the browser entry pulls in ${packageName} (${pulledIn}), which is native-only.`,
+      `Bundling the browser entry pulls in ${packageName} (${pulledIn}), which is React Native only.`,
     );
   }
+}
+
+if (gzip !== withoutAlias.gzip) {
+  throw new Error(
+    `The browser entry is ${formatBytes(gzip)} gzipped with the react-native alias and ${formatBytes(withoutAlias.gzip)} without it. It resolves something through react-native-web, so a web-only app cannot drop the dependency.`,
+  );
 }
 
 if (gzip > gzipBudgetInBytes) {
   throw new Error(
     `The browser entry gzips to ${formatBytes(gzip)}, over the ${formatBytes(gzipBudgetInBytes)} budget. Run \`node tools/measure-web-bundle.mjs\` to see what grew.`,
+  );
+}
+
+// Server rendering imports the module before anything has a DOM. A `document`
+// or `window` read at module scope is a crash in a Next.js server component,
+// and it is the kind of thing that only shows up in someone else's build.
+// Resolved through a URL rather than a bare specifier: `dist` is this script's
+// own input, so it does not exist when `typecheck` runs and tsc would report
+// the literal as an unresolvable module. Turbo runs the two tasks side by side.
+const { MagicModalPortal } = await import(
+  new URL("../dist/index.js", import.meta.url).href
+);
+const { createElement } = await import("react");
+const { renderToStaticMarkup } = await import("react-dom/server");
+const serverMarkup = renderToStaticMarkup(createElement(MagicModalPortal));
+
+if (!serverMarkup.includes('data-testid="magic-modal-portal"')) {
+  throw new Error(
+    `The browser entry rendered no portal on the server. Got: ${serverMarkup}`,
+  );
+}
+
+if (!serverMarkup.includes("<style>")) {
+  throw new Error(
+    "The server-rendered portal carries no stylesheet, so a modal would paint unstyled before hydration.",
   );
 }
 
@@ -199,5 +247,6 @@ console.log(
   `✓ Web package boundary: runtime guard loads first, browser omits ${nativeOnlyPackages.join(", ")}`,
 );
 console.log(
-  `✓ Web bundle: ${formatBytes(minified)} minified, ${formatBytes(gzip)} gzipped (budget ${formatBytes(gzipBudgetInBytes)})`,
+  `✓ Web bundle: ${formatBytes(minified)} minified, ${formatBytes(gzip)} gzipped (budget ${formatBytes(gzipBudgetInBytes)}), identical without the react-native alias`,
 );
+console.log("✓ Web SSR: the portal and its stylesheet render without a DOM");

--- a/packages/modal/tools/measure-web-bundle.mjs
+++ b/packages/modal/tools/measure-web-bundle.mjs
@@ -5,17 +5,32 @@ import { build } from "esbuild";
 /**
  * What a web app actually downloads for this package.
  *
- * The published browser entry still imports from `react-native`, which a web
- * bundler aliases to `react-native-web`, so the file size on disk says nothing
- * about the cost. Bundling it the way a real app does — alias applied, React
- * external because the app already has it, production defines so dev-only
- * branches drop — is the only number worth budgeting against.
+ * The file size on disk says nothing about the cost, so this bundles the
+ * browser entry the way a real app does: React external because the app already
+ * has it, production defines so dev-only branches drop, minified.
+ *
+ * `withReactNativeAlias` applies the `react-native` -> `react-native-web`
+ * alias every react-native-web app configures. The browser entry stopped
+ * importing react-native in v10.1, so it changes nothing — which is the point of
+ * being able to turn it off. Measuring both ways is how the build proves the
+ * browser bundle does not depend on that alias being there, and therefore that
+ * a web-only app needs neither package installed.
  */
 export const measureWebBundle = async ({
   entry = new URL("../dist/index.js", import.meta.url).pathname,
+  withReactNativeAlias = true,
 } = {}) => {
+  // Annotated, and hoisted out of the call, because esbuild infers its result
+  // type from the shape of the options object it is handed. A ternary in there
+  // widens `alias` to a union and takes `metafile` and `outputFiles` down with
+  // it.
+  /** @type {Record<string, string>} */
+  const alias = withReactNativeAlias
+    ? { "react-native": "react-native-web" }
+    : {};
+
   const result = await build({
-    alias: { "react-native": "react-native-web" },
+    alias,
     bundle: true,
     define: {
       __DEV__: "false",
@@ -90,9 +105,13 @@ const isRunDirectly =
 
 if (isRunDirectly) {
   const { gzip, metafile, minified } = await measureWebBundle();
+  const withoutAlias = await measureWebBundle({ withReactNativeAlias: false });
 
   console.log(`minified: ${formatBytes(minified)} (${minified} bytes)`);
   console.log(`gzipped:  ${formatBytes(gzip)} (${gzip} bytes)`);
+  console.log(
+    `\nwithout the react-native -> react-native-web alias: ${formatBytes(withoutAlias.minified)} minified, ${formatBytes(withoutAlias.gzip)} gzipped`,
+  );
   console.log("\nsource bytes per package");
 
   for (const entry of summarizeInputs(metafile)) {


### PR DESCRIPTION
📝 **DESCRIPTION:**

The browser entry no longer imports react-native-web: the web modal renders as plain DOM: `div`s, pointer handlers, enter/exit driven by the Web Animations API (`Element.animate`), and a static `<style>` element in the React tree for layout, and the only remaining import is `react`. This is the companion to the rename, which has since shipped as v10.0.0; this lands on top of it as v10.1.0. It also carries the web-only breaking change on `style` typing.

Measured (esbuild, minified; identical with and without a react-native alias, and the build guard fails if they ever differ):

| | minified | gzip |
|---|---|---|
| before | 96.3 KB | 32.2 KB |
| after | 13.9 KB | 5.3 KB |

Of the removed weight, react-native-web's style pipeline (styleq, inline-style-prefixer, normalize-colors, postcss-value-parser) was 59%; its components and event system the other 41%. A real `next build` of examples/next-web drops 23.8 KB gzip of client JS.

Breaking on the web entry only, and shipping in a minor per this repo's versioning policy (patch never breaks, minor may, major is reserved for era-defining refactors like the v10 rename). The title carries no `!` and there is no `BREAKING-CHANGE` footer anywhere in this description, so the squash commit computes a minor:

- `ModalProps["style"]` and `NewConfigProps["style"]`: `StyleProp<ViewStyle>` -> `React.CSSProperties`. RN style objects (arrays, registered handles, RN-only keys) are detected at runtime and warn once in dev with a migration table instead of being applied.
- `entering`/`exiting` removed from the web type (Reanimated builders, already ignored on web).
- `dist/index.d.ts` no longer references react-native or reanimated types; the native entry's types are unchanged.
- Two observable DOM changes: the backdrop is now `role="presentation"`, and elements carry stable `magic-modal-*` class names instead of RNW's generated `css-*` ones. CSS targeting RNW internals breaks; targeting the new class names is supportable.

SSR: nothing touches `document`/`window` at module scope, and the stylesheet ships in the server HTML, styled before hydration. The build guard server-renders the portal in Node and asserts both the portal and the stylesheet (this caught a real missing-import bug on its first run).

Docs: migration section with a was/now table in `reference/modal-props.mdx`, callout in `platforms/nextjs.mdx`.

Worth doing alongside this: flip the RN peers to optional, simplify the Next.js install guide (no more react-native-web/alias/transpilePackages for web-only apps), and decide whether the `magic-modal-*` class names become documented public API.

🖼 **PRINTS & GIFS:**

No intended visual changes. A geometry probe run against both branches measured identical rectangles for portal, entry, backdrop, motion layer and dialog, and `elementFromPoint` hits the same elements. The next-web browser smoke test passes with zero edits.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

One goal (web entry without react-native-web) in four commits: portal container/back-button injection, the DOM rewrite with the style typing, the build guards, and homing the shared accessibility contract next to the two chromes.

##### Awesome tests or e2e (avoid `shallow` rendering)

127 tests passing — the 119 this branch had, plus the 8 overlay cases #329 added to main. The 28 swipe-arithmetic and 12 motion tests are byte-identical to the previous branch (the modules they pin were not touched). #329's `magic-modal-portal.overlay.test.tsx` was updated for the injected-dependency portal this branch introduces: it now builds its test portal through a helper that takes `isFullWindowOverlaySupported`, and the "outside iOS" case drives that flag instead of swapping `Platform.OS`, since the iOS check moved into `full-window-overlay.tsx`. The jsdom chrome suite was updated for the DOM elements while keeping the `MODAL_DIALOG_TEST_ID` contract, and the browser smoke test (dialog semantics, focus trap, Tab wrap, Escape, backdrop, focus restore, pointer-drag swipe, exit animation) passes unchanged.


