### PR TITLE
fix(docs): serve the site from magic-modal.gabrieltaveira.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="https://gstj.github.io/magic-modal/docs/">Docs</a> | <a href="https://github.com/gstj/magic-modal">GitHub</a> | <a href="https://gstj.github.io/magic-modal/docs/faq/">FAQ</a> | <a href="https://medium.com/@gabrieltaveira/you-have-been-using-react-native-modals-wrong-9b8c17de2f96">Article</a>
+  <a href="https://magic-modal.gabrieltaveira.dev/docs/">Docs</a> | <a href="https://github.com/gstj/magic-modal">GitHub</a> | <a href="https://magic-modal.gabrieltaveira.dev/docs/faq/">FAQ</a> | <a href="https://medium.com/@gabrieltaveira/you-have-been-using-react-native-modals-wrong-9b8c17de2f96">Article</a>
 </p>
 
 ## How it works
@@ -57,7 +57,7 @@ pnpm add react-native-magic-modal
 npx expo install react-native-gesture-handler react-native-reanimated react-native-worklets react-dom react-native-web @expo/metro-runtime
 ```
 
-Read the [Expo guide](https://gstj.github.io/magic-modal/docs/platforms/expo/) for the
+Read the [Expo guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/expo/) for the
 portal and web command.
 
 ### Expo iOS
@@ -75,7 +75,7 @@ npx expo install react-native-gesture-handler react-native-reanimated react-nati
 ```
 
 iOS and Android use the same native dependency set. The
-[native guide](https://gstj.github.io/magic-modal/docs/platforms/ios-android/) covers
+[native guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/ios-android/) covers
 pods, Android back handling, and iOS overlays.
 
 ### Next.js
@@ -85,11 +85,11 @@ pnpm add react-native-magic-modal react-native react-native-web react-native-ges
 ```
 
 Copy the validated alias, extension order, and Client Component setup from the
-[Next.js guide](https://gstj.github.io/magic-modal/docs/platforms/nextjs/). A runnable
+[Next.js guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/). A runnable
 App Router consumer lives in [`examples/next-web`](examples/next-web).
 
 For bare React Native, follow the
-[installation guide](https://gstj.github.io/magic-modal/docs/getting-started/installation/).
+[installation guide](https://magic-modal.gabrieltaveira.dev/docs/getting-started/installation/).
 
 ## Mount the portal
 
@@ -110,7 +110,7 @@ export default function App() {
 ```
 
 With Expo Router, put the same structure in the root `app/_layout.tsx`. Next.js mounts the portal
-inside a Client Component as shown in the [web setup](https://gstj.github.io/magic-modal/docs/platforms/nextjs/).
+inside a Client Component as shown in the [web setup](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/).
 
 ## Return typed data
 
@@ -160,15 +160,15 @@ accessibility escape action. TypeScript exposes `data` after the caller narrows 
 
 ## Documentation
 
-- [Expo Web, iOS, and Android](https://gstj.github.io/magic-modal/docs/platforms/expo/)
-- [Next.js and React Native Web](https://gstj.github.io/magic-modal/docs/platforms/nextjs/)
-- [Modal flows and stacks](https://gstj.github.io/magic-modal/docs/guides/modal-flows/)
-- [Hide results](https://gstj.github.io/magic-modal/docs/reference/hide-results/)
-- [Accessibility](https://gstj.github.io/magic-modal/docs/guides/accessibility/)
-- [Advanced content replacement](https://gstj.github.io/magic-modal/docs/guides/updating-content/)
+- [Expo Web, iOS, and Android](https://magic-modal.gabrieltaveira.dev/docs/platforms/expo/)
+- [Next.js and React Native Web](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/)
+- [Modal flows and stacks](https://magic-modal.gabrieltaveira.dev/docs/guides/modal-flows/)
+- [Hide results](https://magic-modal.gabrieltaveira.dev/docs/reference/hide-results/)
+- [Accessibility](https://magic-modal.gabrieltaveira.dev/docs/guides/accessibility/)
+- [Advanced content replacement](https://magic-modal.gabrieltaveira.dev/docs/guides/updating-content/)
 
 The [kitchen-sink Expo app](examples/kitchen-sink) contains runnable native flows. The
-[interactive site](https://gstj.github.io/magic-modal/) runs the package in the
+[interactive site](https://magic-modal.gabrieltaveira.dev/) runs the package in the
 browser.
 
 ## FAQ
@@ -204,7 +204,7 @@ Inside modal content, use `useMagicModal().hide()`.
 ### How do I render below a native picker on iOS?
 
 Temporarily call `magicModal.disableFullWindowOverlay()`. Restore it in a `finally` block after the
-picker closes. The [native overlay guide](https://gstj.github.io/magic-modal/docs/guides/native-overlays/)
+picker closes. The [native overlay guide](https://magic-modal.gabrieltaveira.dev/docs/guides/native-overlays/)
 contains the complete pattern.
 
 ## Contributors

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -33,15 +33,16 @@ pnpm --filter @magic-modal/docs test
 pnpm --filter @magic-modal/docs typecheck
 ```
 
-Local routes include the production base path:
+The site is served from the root of its own domain, so local routes carry no
+base path:
 
 ```text
-http://localhost:3000/react-native-magic-modal/
+http://localhost:3000/
 ```
 
 `pnpm docs` checks the full static artifact after building. The check covers
-GitHub Pages asset prefixes, generated Markdown quality, agent-readable output,
-and every legacy TypeDoc URL.
+asset prefixes, generated Markdown quality, agent-readable output, and every
+legacy TypeDoc URL.
 
 ## Content rule
 

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -9,7 +9,7 @@ const presetSite = defineMagicDocs({
   description:
     "Open a modal from any async flow, await its typed result, and keep concurrent prompts in one ordered stack across web, iOS, and Android.",
   repository: "https://github.com/GSTJ/magic-modal",
-  siteUrl: "https://gstj.github.io/magic-modal",
+  siteUrl: "https://magic-modal.gabrieltaveira.dev",
   packageName: "react-native-magic-modal",
   docsPath: "/docs",
 });

--- a/apps/docs/scripts/check-artifact.mjs
+++ b/apps/docs/scripts/check-artifact.mjs
@@ -48,8 +48,11 @@ const visit = async (directory) => {
 await visit(outputDirectory);
 
 const html = await Promise.all(htmlFiles.map((path) => readFile(path, "utf8")));
-if (html.some((content) => /(?:href|src)="\/_next\//u.test(content))) {
-  throw new Error("Found a Next asset URL without the GitHub Pages base path.");
+if (
+  deploymentBasePath &&
+  html.some((content) => /(?:href|src)="\/_next\//u.test(content))
+) {
+  throw new Error("Found a Next asset URL without the deployment base path.");
 }
 
 const internalLinks = [];

--- a/apps/docs/scripts/write-legacy-redirects.mjs
+++ b/apps/docs/scripts/write-legacy-redirects.mjs
@@ -1,7 +1,7 @@
 import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
-export const deploymentBasePath = "/magic-modal";
+export const deploymentBasePath = "";
 
 export const legacyRedirects = {
   "enums/MagicModalHideReason.html": "/docs/reference/hide-results/",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/GSTJ/magic-modal/issues"
   },
-  "homepage": "https://gstj.github.io/magic-modal/",
+  "homepage": "https://magic-modal.gabrieltaveira.dev/",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -12,7 +12,7 @@
     "react-native-web",
     "web"
   ],
-  "homepage": "https://gstj.github.io/magic-modal/",
+  "homepage": "https://magic-modal.gabrieltaveira.dev/",
   "bugs": {
     "url": "https://github.com/GSTJ/magic-modal/issues"
   },

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "react-native-magic-modal",
-  "homepage": "https://gstj.github.io/magic-modal/",
+  "homepage": "https://magic-modal.gabrieltaveira.dev/",
   "items": [
     {
       "name": "magic-modal",

--- a/registry/README.md
+++ b/registry/README.md
@@ -78,7 +78,7 @@ pnpm docs:dev
 Preview the install from another project with a `components.json` file:
 
 ```bash
-pnpm dlx shadcn@4.16.0 add http://localhost:3000/react-native-magic-modal/r/magic-modal.json --dry-run
+pnpm dlx shadcn@4.16.0 add http://localhost:3000/r/magic-modal.json --dry-run
 ```
 
 Drop `--dry-run` to copy the component. The target comes from


### PR DESCRIPTION
📝 **DESCRIPTION:**

The live site is broken right now. `magic-modal.gabrieltaveira.dev` returns 200, but the HTML it serves references `/magic-modal/_next/...` for every stylesheet and script and `/magic-modal/docs/` for every link. The domain serves from its root, so all 23 of those URLs 404. The landing page is raw unstyled markup with dead navigation. The same paths without the prefix (`/_next/...`, `/docs/`) return 200, which is the whole bug.

How it got here: #333 was meant to carry the domain switch, but it merged at `9be169d`, one commit before `08e246d` ("serve the site from magic-modal.gabrieltaveira.dev") landed on its branch. That commit is still sitting on `fix/links-after-repo-rename`, stranded, because the PR that would have carried it is already merged and closed. So main got the `gstj.github.io/react-native-magic-modal` -> `gstj.github.io/magic-modal` half of the migration and not the domain half. This PR is that commit, rebased onto main.

magic-docs derives Next's `basePath` from the pathname of `siteUrl`, so pointing `siteUrl` at the apex domain empties it. `deploymentBasePath` in `write-legacy-redirects.mjs` is the separate copy the legacy TypeDoc redirect writer and the artifact checker read, and it moves in the same commit or every redirect would point one level deep.

`check-artifact.mjs` asserted that no asset URL starts with `/_next/`. That is what a project-path deployment needs and what this deployment now produces, so the assertion is made conditional on there being a base path to look for.

The Pages custom domain is already configured, CNAME set, HTTPS enforced, and `gstj.github.io/magic-modal` already 301s to it. Nothing outside this repo needs to change: merging this and letting the docs workflow deploy completes the migration.

Not in scope: the `homepage` fields move to the domain here, but the npm package name is untouched. That rename is #335.

🖼 **PRINTS & GIFS:**

Before, from the live site:

```
$ curl -s https://magic-modal.gabrieltaveira.dev/ | grep -o 'href="[^"]*_next[^"]*"' | head -2
href="/magic-modal/_next/static/chunks/3n6-5g125cv8f.css"
href="/magic-modal/_next/static/chunks/1b3_130_i5gv9.css"

$ curl -o /dev/null -sw '%{http_code}\n' https://magic-modal.gabrieltaveira.dev/magic-modal/_next/static/chunks/3n6-5g125cv8f.css
404
$ curl -o /dev/null -sw '%{http_code}\n' https://magic-modal.gabrieltaveira.dev/_next/static/chunks/3n6-5g125cv8f.css
200
```

After, from the static export this branch produces:

```
$ grep -o '"/_next/static/chunks/[^"]*\.css"' apps/docs/out/index.html | head -2
"/_next/static/chunks/3n6-5g125cv8f.css"
"/_next/static/chunks/1b3_130_i5gv9.css"

$ grep -ro '"/magic-modal/' apps/docs/out/ | wc -l
0
```

Canonical and sitemap come out on the domain: `rel="canonical" href="https://magic-modal.gabrieltaveira.dev/"`, `<loc>https://magic-modal.gabrieltaveira.dev/docs/faq</loc>`.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

One thing: the site's deployed URL. `siteUrl` and `deploymentBasePath` are the two halves of it, the artifact guard has to follow or the build fails on its own output, and the `homepage` fields and the two localhost URLs documenting the dev base path are the same URL written down elsewhere. 9 files.

##### Awesome tests or e2e (avoid `shallow` rendering)

`pnpm build` runs the full static export and `check-artifact.mjs` against it: 24 required files, 37 HTML files, 826 internal links, all green, including the legacy TypeDoc redirect set that `deploymentBasePath` feeds. `pnpm typecheck` 5/5, `pnpm test` 5/5, `pnpm format` clean, oxlint run directly (one pre-existing warning in `examples/next-web/tools/browser-smoke.mjs`, untouched here).
