### PR TITLE
fix(release): drop the em-dashes from the deprecate message

### DIFF
--- a/packages/react-native-magic-modal/tools/release.mjs
+++ b/packages/react-native-magic-modal/tools/release.mjs
@@ -16,7 +16,7 @@ import { readFile } from "node:fs/promises";
 import { syncManifest } from "./sync-manifest.mjs";
 
 const DEPRECATION_MESSAGE =
-  "Renamed to `magic-modal`. This package still works and still tracks every release — it depends on `magic-modal` and re-exports it — but new code should install `magic-modal` instead. See https://github.com/GSTJ/magic-modal";
+  "Renamed to `magic-modal`. This package still works and still tracks every release, since it depends on `magic-modal` and re-exports it, but new code should install `magic-modal` instead. See https://github.com/GSTJ/magic-modal";
 
 /**
  * @param {string} command


### PR DESCRIPTION
📝 **DESCRIPTION:**

The deprecate notice on `react-native-magic-modal` used em-dashes around the middle clause, which
the house style doesn't use. Swapped them for commas. Same sentence, same meaning, one word added
("since") so the clause still reads as a reason rather than a run-on.

Before:

> ...still tracks every release — it depends on `magic-modal` and re-exports it — but new code...

After:

> ...still tracks every release, since it depends on `magic-modal` and re-exports it, but new code...

The live message is already fixed. `npm deprecate react-native-magic-modal@"*"` was re-run by hand
with this exact string, so all 114 published versions including 10.0.0 now carry it. Deprecate
messages are mutable and this only rewrites the `deprecated` field, so nothing was unpublished and
no install broke. This PR keeps the script in sync so the next shim release re-stamps the same
wording instead of putting the em-dashes back.

Verified:

```
$ npm view react-native-magic-modal@latest deprecated
Renamed to `magic-modal`. This package still works and still tracks every release, since it depends on `magic-modal` and re-exports it, but new code should install `magic-modal` instead. See https://github.com/GSTJ/magic-modal
```

🖼 **PRINTS & GIFS:**

Not applicable, this is a string in a release script.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing?

Yes. One string constant in `packages/react-native-magic-modal/tools/release.mjs`.

##### Awesome tests or e2e

No. It's a release script, and the constant it changes is only read by `npm deprecate` at publish
time. The live registry output above is the check that matters.
