### PR TITLE
docs(changelog): drop the PR body that leaked into the 10.0.0 breaking note

### DIFF
--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -12,31 +12,6 @@
   it, so an existing install resolves to the same code; npm shows a deprecation
   notice on it pointing here. Install `magic-modal` and update the import
   specifier.
-  ```
-
-  This is the v10 gate. Merging it computes a `major` bump (verified
-  through the repo's own `conventional-recommended-bump` preset) and
-  renames the published package, so it merges last, after the in-flight v9
-  work.
-
-  The package renames to `magic-modal`. The old name stays alive as a
-  lockstep alias: `packages/react-native-magic-modal` depends on
-  `magic-modal` at `workspace:*` (pnpm rewrites it to the exact version at
-  pack time) and every entry is `export * from "magic-modal"`, mirroring
-  the export map condition for condition. `import.meta.resolve` probes
-  confirm both the default and `react-native` conditions forward to the
-  same files as importing `magic-modal` directly, and a tsc probe confirms
-  the types forward (a wrong `Direction` value errors instead of
-  collapsing to `any`).
-
-  Release wiring: the root `release` script publishes `magic-modal` via
-  release-it, then runs the alias's `tools/release.mjs`, which syncs the
-  version, publishes with `pnpm publish` (npm would ship the unrewritten
-  `workspace:*`), and runs `npm deprecate` on the old name after every
-  publish. The deprecate is per-publish rather than a one-off because npm
-  resolves the range when the command runs: a single deprecate at v10
-  would leave every later alias version, the one installs actually resolve
-  to, without the notice.
 
 ### :hammer: Bug Fixes :hammer:
 


### PR DESCRIPTION
📝 **DESCRIPTION:**

The v10 squash commit carried the whole PR description, so conventional-changelog copied everything
after the `BREAKING CHANGE:` trailer into the note. The 10.0.0 entry ends up with a stray code fence
and then three paragraphs of PR-review context: the merge-order rationale, the `import.meta.resolve`
and tsc probes, and the release wiring for the shim publish. That's reviewer material, not something
a consumer reading a changelog needs.

This drops it and keeps the part that tells someone what to do: the package is now `magic-modal`,
the old name still resolves to the same code, install `magic-modal` and update the import specifier.
The features, fixes and other sections are untouched.

The GitHub release body for `magic-modal-10.0.0` had the same leak and has already been edited to
match this.

This is a follow-up to #339 rather than a change on that branch. #339 had auto-merge armed by the
release workflow and merged before this could be pushed to it.

🖼 **PRINTS & GIFS:**

Not applicable, markdown only.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing?

Yes. 25 deleted lines in `packages/modal/CHANGELOG.md`, all inside the 10.0.0 breaking note.

##### Awesome tests or e2e

No. It's a generated changelog file with no consumers in the build.
