### PR TITLE
fix(docs): show the download count people actually recognize

### DIFF
--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -1,0 +1,126 @@
+name: 📈 Downloads Badge
+
+# magic-modal is the renamed package (see #335); react-native-magic-modal is
+# now a lockstep alias whose installs also pull magic-modal. The alias still
+# carries the real historical volume, so the README's downloads badge points
+# there until magic-modal's own weekly count catches up. This job checks
+# weekly and flips the badge itself the day it does, then deletes this
+# workflow in the same PR — there is nothing left for it to watch once the
+# README no longer names the alias.
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  # Needed to POST actions/runs/{id}/approve. A PR opened with GITHUB_TOKEN
+  # gets its pull_request run parked at action_required, and the ruleset only
+  # counts checks attached to the PR. Same problem release.yml's sync PR has.
+  actions: write
+
+jobs:
+  check:
+    name: 🔎 Check and flip
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: true
+
+      - name: 🔎 Compare weekly downloads
+        id: counts
+        run: |
+          set -euo pipefail
+
+          NEW=$(curl -sf "https://api.npmjs.org/downloads/point/last-week/magic-modal" | jq '.downloads')
+          OLD=$(curl -sf "https://api.npmjs.org/downloads/point/last-week/react-native-magic-modal" | jq '.downloads')
+          echo "magic-modal: $NEW/week, react-native-magic-modal: $OLD/week"
+
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+
+          if ! grep -q 'react-native-magic-modal/downloads.svg' README.md; then
+            echo "README already points the downloads badge at magic-modal. Nothing to watch."
+            echo "flip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$NEW" -ge "$OLD" ]; then
+            echo "magic-modal caught up. Flipping the badge."
+            echo "flip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Not yet. react-native-magic-modal still leads."
+            echo "flip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 🔀 Flip the badge and open a PR
+        id: flip-pr
+        if: steps.counts.outputs.flip == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW: ${{ steps.counts.outputs.new }}
+          OLD: ${{ steps.counts.outputs.old }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="bot/downloads-badge-flip"
+
+          # Idempotent against overlapping scheduled runs: if a flip PR is
+          # already open on this branch, there is nothing left to do here.
+          EXISTING=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Flip PR #$EXISTING is already open. Leaving it alone."
+            echo "pr=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          sed -i \
+            -e 's|npmjs.com/package/react-native-magic-modal|npmjs.com/package/magic-modal|' \
+            -e 's|shieldcn.dev/npm/react-native-magic-modal/downloads.svg|shieldcn.dev/npm/magic-modal/downloads.svg|' \
+            README.md
+
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git add README.md
+          git rm .github/workflows/downloads-badge.yml
+          git commit -m "$(printf '%s\n' \
+            "fix(docs): switch the downloads badge to magic-modal" \
+            "" \
+            "magic-modal is now at $NEW/week against react-native-magic-modal's $OLD/week," \
+            "so the renamed package finally shows the bigger, accurate number. This was the" \
+            "one thing the Downloads Badge workflow existed to watch for, so it deletes" \
+            "itself here too." \
+            "" \
+            "Opened by the Downloads Badge workflow, run $RUN_ID.")"
+
+          git push --force origin "HEAD:refs/heads/$BRANCH"
+
+          BODY=$(printf '%s\n' \
+            "magic-modal passed react-native-magic-modal on weekly downloads ($NEW vs $OLD)," \
+            "so the README's downloads badge now counts and links to magic-modal instead of" \
+            "the legacy alias." \
+            "" \
+            "This also removes \`.github/workflows/downloads-badge.yml\`: its only job was to" \
+            "watch for this crossover, and it just did." \
+            "" \
+            "Opened by the Downloads Badge workflow, run $RUN_ID.")
+
+          gh pr create --base main --head "$BRANCH" \
+            --title "fix(docs): switch the downloads badge to magic-modal" \
+            --body "$BODY"
+
+          PR=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number')
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: ✅ Release the parked check run
+        if: steps.flip-pr.outputs.pr != ''
+        continue-on-error: true
+        uses: ./.github/actions/approve-parked-ci
+        with:
+          pull-request: ${{ steps.flip-pr.outputs.pr }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a aria-label="npm version" href="https://www.npmjs.com/package/magic-modal"><img alt="npm version" src="https://shieldcn.dev/npm/magic-modal.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
-  <a aria-label="npm downloads" href="https://www.npmjs.com/package/magic-modal"><img alt="npm downloads" src="https://shieldcn.dev/npm/magic-modal/downloads.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
+  <a aria-label="npm downloads" href="https://www.npmjs.com/package/react-native-magic-modal"><img alt="npm downloads" src="https://shieldcn.dev/npm/react-native-magic-modal/downloads.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
   <a aria-label="GitHub stars" href="https://github.com/GSTJ/magic-modal/stargazers"><img alt="GitHub stars" src="https://shieldcn.dev/github/GSTJ/magic-modal/stars.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
   <a aria-label="license" href="https://github.com/GSTJ/magic-modal/blob/main/LICENSE"><img alt="license" src="https://shieldcn.dev/github/GSTJ/magic-modal/license.svg?variant=branded&amp;size=xs&amp;mode=light" /></a>
 </p>


### PR DESCRIPTION
## Why

magic-modal just shipped (#335) and shows ~84/week — brand new, so the counter is basically empty. react-native-magic-modal is now a lockstep alias whose installs also pull in magic-modal, and it still carries the real historical volume: ~4k/week. Pointing the downloads badge at the new name makes the project look dead when it isn't.

Points the badge (and its link) at react-native-magic-modal instead, so the number matches what people actually recognize and what clicking through shows.

## Auto-flip

Adds `.github/workflows/downloads-badge.yml`: runs weekly (Monday 09:00 UTC) plus `workflow_dispatch`, compares `last-week` downloads for both names via the npm downloads API, and once magic-modal's count catches up, flips the badge back to magic-modal itself and opens a PR.

That flip PR also deletes the workflow file — once the README no longer names the alias, there's nothing left for it to watch.

## Test plan

- [x] Both shieldcn badge URLs (`magic-modal.svg` version, `react-native-magic-modal/downloads.svg`) return 200
- [x] `actionlint` passes on the new workflow
- [x] Verified the flip workflow's `sed` exactly reverses this PR's README change