### PR TITLE
fix(release): stop the shim deprecating its own latest version

### DIFF
--- a/packages/react-native-magic-modal/tools/release.mjs
+++ b/packages/react-native-magic-modal/tools/release.mjs
@@ -48,17 +48,49 @@ run("pnpm", ["publish", "--no-git-checks", "--access", "public"]);
 
 // Deprecate after publishing, not before, and re-run it on every release.
 //
-// `npm deprecate pkg@"*"` resolves the range against the versions that exist at
-// the moment it runs and writes a `deprecated` field into each one. It is not a
-// standing rule: a version published afterwards is not deprecated, which is why
-// this cannot be a one-off command run by hand at v10. Every shim release has
-// to re-apply it or the newest version — the one `npm install
-// react-native-magic-modal` actually resolves to — would be the only
-// undeprecated version on the package, and nobody would ever see the notice.
+// `npm deprecate pkg@<range>` resolves the range against the versions that
+// exist at the moment it runs and writes a `deprecated` field into each one. It
+// is not a standing rule: a version published afterwards is not deprecated,
+// which is why this cannot be a one-off command run by hand at v10. Every shim
+// release has to re-apply it.
+//
+// The range is everything BELOW the version just published, not `*`, and the
+// newest version is deliberately left undeprecated. That is not a style choice,
+// it is forced by how npm resolves a bare `npm install <pkg>`:
+//
+//   npm-pick-manifest takes the `latest` dist-tag as a shortcut only when that
+//   manifest is not deprecated. Deprecate it and the shortcut is skipped, and
+//   resolution falls through to the highest version satisfying the range,
+//   whatever `latest` says.
+//
+// `react-native-magic-modal@11.0.0` is an accidental major that sits above
+// `latest` and cannot be removed: npm refuses to unpublish this package because
+// it has dependents in the registry. Its own `magic-modal@11.0.0` dependency
+// WAS unpublished, so 11.0.0 no longer installs at all, it fails to resolve.
+//
+// So deprecating the newest version here would point every bare
+// `npm install react-native-magic-modal` at a version that errors out. Measured,
+// not assumed: with 10.1.0 deprecated a bare install resolved to 11.0.0, and
+// undeprecating it moved resolution back to 10.1.0.
+//
+// The cost is that whoever installs `latest` sees no rename notice, which is the
+// exact thing the old `*` range was written to guarantee. There is no way to
+// have both while a higher version exists, and a missing notice beats a failed
+// install. Anyone on an older version still gets it, and the README, the npm
+// page and the repo all say the package was renamed.
+//
+// This can go back to `*` only once `latest` is itself above 11.0.0, since the
+// fallthrough would then land on `latest` anyway. Note that 11.0.0 is burned on
+// both packages and can never be republished, so that era starts at 11.0.1 or
+// 12.0.0.
 //
 // Deprecation is a warning printed at install time. It does not unpublish, does
 // not block installs and does not break existing lockfiles.
-run("npm", ["deprecate", `react-native-magic-modal@*`, DEPRECATION_MESSAGE]);
+run("npm", [
+  "deprecate",
+  `react-native-magic-modal@<${version}`,
+  DEPRECATION_MESSAGE,
+]);
 
 // Get the bump into the release commit's branch so the sync PR carries it to
 // main. release-it committed the real package's bump before this script ran, so


### PR DESCRIPTION
Follow-up to #345. This one is time-sensitive: as it stands, the next shim release breaks `npm i react-native-magic-modal` for everyone.

## What changed on the registry first

`magic-modal@11.0.0` was unpublished inside npm's 72h window. `react-native-magic-modal@11.0.0` could not be: npm refuses to unpublish that package because it has dependents in the registry.

```
npm error 405 Method Not Allowed
npm error Failed criteria:
npm error has dependent packages in the registry
```

So the shim's 11.0.0 still exists, still sits above `latest`, and now declares a dependency on a version that no longer exists. It fails to resolve:

```
npm error notarget No matching version found for magic-modal@11.0.0
```

Neither can be undone. An unpublished version can never be republished, so 11.0.0 is burned on both packages. The next real major is 11.0.1 or 12.0.0.

## Why this is urgent

npm-pick-manifest only takes the `latest` dist-tag as a shortcut when that manifest is not deprecated. Otherwise it falls through to the highest version satisfying the range, whatever `latest` says.

`tools/release.mjs` ran `npm deprecate react-native-magic-modal@*` on every release, which deprecates the version it just published. With 11.0.0 sitting above `latest` and now unresolvable, the next release would have pointed every bare `npm i react-native-magic-modal` at a hard failure.

Measured in both directions rather than assumed: deprecating 10.1.0 moved a bare install to 11.0.0, and undeprecating it moved resolution back to 10.1.0.

## The change

The deprecation range is now everything strictly below the version being published, instead of `*`. Latest stays clean and resolvable, everything under it still carries the rename notice.

Already applied by hand to match, so the registry is in the end state this code will reproduce:

```
9.0.0 - 10.1.0   renamed-to-magic-modal notice
10.1.1           not deprecated  (latest)
11.0.0           accidental major, no longer installable
```

Verified with fresh-cache scratch installs:

| command | resolves | notice |
|---|---|---|
| `npm i magic-modal` | 10.1.1 | clean |
| `npm i react-native-magic-modal` | 10.1.1 (nested 10.1.1) | clean |
| `npm i react-native-magic-modal@^9` | 9.2.0 | rename notice shown |

## The cost, stated plainly

Whoever installs `latest` sees no rename notice. That is exactly what the old `*` range was written to guarantee, and the comment it replaces argued for it correctly.

There is no way to have both while a higher version exists: the notice requires deprecating latest, and deprecating latest breaks resolution. A missing notice beats a failed install. Anyone on an older version still gets it, and the README, the npm page and the repo all say the package was renamed.

This can go back to `*` once `latest` is itself above 11.0.0, since the fallthrough would then land on `latest` anyway. Worth revisiting then, not before.
