### PR TITLE
fix(release): skip the burned 11.0.0 when computing the next version

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -35,10 +35,13 @@ jobs:
       # a synthetic history of every commit type through the real changelog
       # preset and fails if a breaking change goes missing — including one
       # hanging off a hidden type, which is how a `ci!:` would vanish.
+      # release:check drives the real .release-it.js against a throwaway repo
+      # at 10.1.1 and fails if the next major computes 11.0.0, which npm can
+      # never accept again (unpublished on magic-modal, occupied on the shim).
       #
       # One `extra-command`, so they're chained. `&&` short-circuits, which is
-      # what we want: either failing fails the job.
-      extra-command: pnpm run doctor && pnpm run changelog:check
+      # what we want: any failing fails the job.
+      extra-command: pnpm run doctor && pnpm run changelog:check && pnpm run release:check
 
   # main's ruleset requires a check literally named "👮‍♂️ Typecheck, Healthcheck,
   # Lint and Format". A called workflow always reports as

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start": "turbo run start",
     "test": "turbo run test",
     "changelog:check": "turbo run changelog:check --filter=magic-modal",
+    "release:check": "turbo run release:check --filter=magic-modal",
     "build": "turbo run build",
     "release": "turbo run release --filter=magic-modal && pnpm --filter react-native-magic-modal run release",
     "docs": "pnpm --filter magic-modal build && pnpm --filter @magic-modal/docs build",

--- a/packages/modal/.release-it.js
+++ b/packages/modal/.release-it.js
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import createPreset from "conventional-changelog-conventionalcommits";
 
 // One list, used three times: as the preset the plugin loads, to build the
@@ -87,9 +89,22 @@ const preset =
     /** @type {unknown} */ (await createPreset({ types }))
   );
 
+// The conventional-changelog plugin is loaded through the subclass in
+// tools/skip-burned-versions.mjs, which remaps a computed version npm would
+// refuse (11.0.0 is burned on both packages) to one it accepts. Same plugin,
+// same options, one override; that file has the whole story.
+//
+// The key is an absolute path on purpose. release-it resolves relative plugin
+// paths against process.cwd(), not against this config file, and
+// tools/burned-version-check.mjs runs this exact config from a throwaway repo
+// in a temp dir — a `./tools/...` key would resolve there and load nothing.
+const SKIP_BURNED_PLUGIN = fileURLToPath(
+  new URL("tools/skip-burned-versions.mjs", import.meta.url),
+);
+
 export default {
   plugins: {
-    "@release-it/conventional-changelog": {
+    [SKIP_BURNED_PLUGIN]: {
       infile: "CHANGELOG.md",
       header: "# 🦄 Magic Modal Changelog 🪄",
       // Where the recommended bump starts counting from. Without it,

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -69,6 +69,7 @@
     "prepack": "pnpm run copy:readme",
     "test": "jest",
     "changelog:check": "node tools/changelog-check.mjs",
+    "release:check": "node tools/burned-version-check.mjs",
     "release": "release-it --ci"
   },
   "devDependencies": {

--- a/packages/modal/tools/burned-version-check.mjs
+++ b/packages/modal/tools/burned-version-check.mjs
@@ -1,0 +1,205 @@
+// Control for tools/skip-burned-versions.mjs.
+//
+// The plugin exists because 11.0.0 is unpublishable on npm (unpublished on
+// magic-modal, occupied on react-native-magic-modal) while every version
+// source in this repo says 10.1.1, so the next major computes exactly the
+// version npm refuses. The failure mode of the guard itself is silence: if a
+// release-it upgrade stops calling `getRecommendedVersion`, or the plugin
+// falls out of the config, the pipeline goes right back to computing 11.0.0
+// and nothing says so until a real release is rejected mid-publish.
+//
+// So this drives the REAL `.release-it.js` — not a copy, not the plugin in
+// isolation — against a throwaway repo shaped like the hazard: package.json
+// at 10.1.1, latest tag magic-modal-10.1.1, one synthetic breaking commit.
+// Three things get checked:
+//
+//   1. the burned map says what the registry surgery decided: 11.0.0 -> 12.0.0
+//   2. `release-it --release-version` through the real config prints 12.0.0
+//      for a breaking commit, and an ordinary fix still prints 10.1.2 — the
+//      guard only touches the poisoned result
+//   3. the same repo through the raw @release-it/conventional-changelog
+//      plugin, same options, prints 11.0.0 — proving the subclass is the
+//      thing doing the work, and that the underlying bump math still lands on
+//      the burned number. An assertion that cannot fail is worth nothing.
+//
+// The throwaway repo is deliberately private, so release-it's npm plugin
+// skips its registry/auth checks and the whole run is hermetic. Its
+// `latestVersion` still comes from package.json, same as the real release.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { BURNED_VERSIONS } from "./skip-burned-versions.mjs";
+
+const here = import.meta.dirname;
+const realConfig = join(here, "..", ".release-it.js");
+
+// Resolved rather than assumed to sit at ../node_modules/.bin: pnpm hoists,
+// and in a workspace the binary can land in the root store instead of the
+// package. Resolve the package entry (lib/index.js) and walk to the bin.
+const releaseItEntry = fileURLToPath(import.meta.resolve("release-it"));
+const releaseItBin = join(
+  dirname(releaseItEntry),
+  "..",
+  "bin",
+  "release-it.js",
+);
+
+/**
+ * Builds a throwaway repo shaped like the hazard — version 10.1.1 everywhere,
+ * one release commit on top — and hands it to `run`. The bare "origin" exists
+ * because release-it's git plugin refuses to run on a branch with no
+ * upstream.
+ *
+ * @template T
+ * @param {string} commitMessage
+ * @param {(repo: string) => T | Promise<T>} run
+ * @returns {Promise<T>}
+ */
+const inThrowawayRepo = async (commitMessage, run) => {
+  const repo = mkdtempSync(join(tmpdir(), "magic-modal-burned-"));
+  const origin = mkdtempSync(join(tmpdir(), "magic-modal-burned-origin-"));
+  /** @param {string[]} args */
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: repo, encoding: "utf8", stdio: "pipe" });
+
+  try {
+    execFileSync("git", ["init", "--bare", "--quiet", origin]);
+    git("init", "--quiet", "--initial-branch", "main");
+    git("config", "user.email", "check@example.com");
+    git("config", "user.name", "burned version check");
+    writeFileSync(
+      join(repo, "package.json"),
+      JSON.stringify({
+        name: "burned-version-check",
+        version: "10.1.1",
+        private: true,
+      }),
+    );
+    git("add", ".");
+    git("commit", "--quiet", "-m", "chore: initial");
+    git("tag", "-a", "magic-modal-10.1.1", "-m", "magic-modal-10.1.1");
+    git("remote", "add", "origin", origin);
+    git("push", "--quiet", "--set-upstream", "origin", "main");
+    git(
+      "commit",
+      "--quiet",
+      "--allow-empty",
+      "--cleanup=verbatim",
+      "-m",
+      commitMessage,
+    );
+
+    return await run(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(origin, { recursive: true, force: true });
+  }
+};
+
+/**
+ * What `release-it --release-version` prints for `commitMessage` under
+ * `configPath`. Warnings can share stdout with the answer, so the version is
+ * the last non-empty line.
+ *
+ * @param {string} commitMessage
+ * @param {string} configPath
+ * @returns {Promise<string>}
+ */
+const releaseVersionFor = (commitMessage, configPath) =>
+  inThrowawayRepo(commitMessage, (repo) => {
+    const output = execFileSync(
+      process.execPath,
+      [releaseItBin, "--release-version", "--ci", "--config", configPath],
+      { cwd: repo, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return output.trim().split("\n").at(-1)?.trim() ?? "";
+  });
+
+const BREAKING =
+  "feat(modal)!: synthetic breaking change\n\nBREAKING CHANGE: synthetic, never pushed anywhere";
+const ORDINARY = "fix(modal): synthetic fix";
+
+/** @type {string[]} */
+const failures = [];
+/**
+ * @param {string} label
+ * @param {boolean} condition
+ */
+const expect = (label, condition) => {
+  if (!condition) failures.push(label);
+};
+
+// 1. The map states the policy the registry surgery decided.
+expect(
+  `the burned map skips 11.0.0 to 12.0.0 (got ${BURNED_VERSIONS["11.0.0"]})`,
+  BURNED_VERSIONS["11.0.0"] === "12.0.0",
+);
+
+// 2. The real config remaps the major and leaves an ordinary fix alone.
+const guardedMajor = await releaseVersionFor(BREAKING, realConfig);
+expect(
+  `a breaking commit over 10.1.1 releases 12.0.0 through the real config (got ${guardedMajor})`,
+  guardedMajor === "12.0.0",
+);
+
+const guardedPatch = await releaseVersionFor(ORDINARY, realConfig);
+expect(
+  `a fix over 10.1.1 still releases 10.1.2 (got ${guardedPatch})`,
+  guardedPatch === "10.1.2",
+);
+
+// 3. Negative control: the raw plugin with the same options computes the
+// burned 11.0.0. Written next to the real config so its relative import and
+// the bare specifier both resolve; the plugin key is an absolute path for the
+// same reason the real config's is — release-it resolves plugin names against
+// the throwaway repo's cwd, where nothing is installed.
+const controlConfig = join(
+  here,
+  "..",
+  `.release-it-control.${process.pid}.mjs`,
+);
+writeFileSync(
+  controlConfig,
+  [
+    'import { fileURLToPath } from "node:url";',
+    "",
+    'import real from "./.release-it.js";',
+    "",
+    "const ccPlugin = fileURLToPath(",
+    '  import.meta.resolve("@release-it/conventional-changelog"),',
+    ");",
+    "",
+    "export default {",
+    "  ...real,",
+    "  plugins: { [ccPlugin]: Object.values(real.plugins)[0] },",
+    "};",
+    "",
+  ].join("\n"),
+);
+
+let unguardedMajor;
+try {
+  unguardedMajor = await releaseVersionFor(BREAKING, controlConfig);
+} finally {
+  rmSync(controlConfig, { force: true });
+}
+
+if (unguardedMajor !== "11.0.0") {
+  console.error(
+    `negative control FAILED: the raw plugin computed ${unguardedMajor}, not the burned 11.0.0, so the assertions above are not testing the guard.`,
+  );
+  process.exit(1);
+}
+
+if (failures.length > 0) {
+  console.error("burned version check FAILED:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  `burned version check passed (breaking over 10.1.1: guarded=${guardedMajor}, raw plugin=${unguardedMajor}; fix over 10.1.1: ${guardedPatch})`,
+);

--- a/packages/modal/tools/release-it-conventional-changelog.d.ts
+++ b/packages/modal/tools/release-it-conventional-changelog.d.ts
@@ -1,0 +1,21 @@
+// @release-it/conventional-changelog ships no types, and release-it's own
+// `declare module "release-it"` shorthand means the Plugin base class is
+// typeless anyway, so there is nothing upstream to inherit from. This declares
+// only what tools/skip-burned-versions.mjs actually touches: the class and
+// the one method it overrides, with the argument shape the plugin's
+// `getRecommendedVersion` destructures.
+declare module "@release-it/conventional-changelog" {
+  interface RecommendedVersionOptions {
+    increment?: string;
+    latestVersion?: string;
+    isPreRelease?: boolean;
+    preReleaseId?: string;
+    preReleaseBase?: string | number;
+  }
+
+  export default class ConventionalChangelog {
+    getRecommendedVersion(
+      options: RecommendedVersionOptions,
+    ): Promise<string | null>;
+  }
+}

--- a/packages/modal/tools/skip-burned-versions.mjs
+++ b/packages/modal/tools/skip-burned-versions.mjs
@@ -1,0 +1,71 @@
+// The conventional-changelog release-it plugin, with one extra rule: a
+// computed version that npm can never accept is skipped forward.
+//
+// 11.0.0 is unpublishable on both packages, permanently:
+//
+//   - `magic-modal@11.0.0` was published by accident and unpublished. npm
+//     burns an unpublished version string forever, so a republish is refused.
+//   - `react-native-magic-modal@11.0.0` could not even be unpublished (npm
+//     refuses on packages with registry dependents), so it still exists,
+//     deprecated, above `latest`. Publishing over an existing version is
+//     refused too.
+//
+// Meanwhile every version source this pipeline reads says 10.1.1: the
+// `magic-modal-11.0.0` git tag was deleted, main's package.json was synced
+// back, and npm `latest` points at 10.1.1. So the next `feat(modal)!` computes
+// 10.1.1 + major = 11.0.0, release-it tags it, cuts the GitHub release, and
+// `npm publish` is then rejected — the registry untouched, the repo convinced
+// it released. Measured, not assumed: on a branch with a synthetic
+// `feat(modal)!` commit, `release-it --release-version --ci` printed 11.0.0.
+//
+// Overriding `getRecommendedVersion` is the one seam that catches every path a
+// bump takes to become a version: the changelog header, the tag name, the
+// GitHub release and the npm publish all read the remapped value, so they
+// cannot disagree. A check bolted onto the release.yml probe instead would be
+// a second opinion about the version, and probe/preset disagreement is exactly
+// how 11.0.0 shipped in the first place. The bump math itself stays
+// upstream's; only the poisoned result is remapped, loudly.
+import ConventionalChangelog from "@release-it/conventional-changelog";
+
+// Computed version -> version to release instead. 11.0.0 skips to 12.0.0
+// rather than shipping "11.0.1 as the major": semver tooling reads 11.0.1 as
+// a patch of an 11 line that never worked, and anyone who installed the
+// accident and ranged `^11.0.0` would silently resolve onto a breaking
+// release dressed as a patch. A gap in the number line costs nothing.
+//
+// `react-native-magic-modal@12.0.0` publishes fine too — the shim mirrors
+// whatever version tools/release.mjs finds in this package's package.json,
+// and 12.0.0 exists on neither package.
+//
+// tools/burned-version-check.mjs asserts this map and the remap end to end.
+/** @type {Readonly<Partial<Record<string, string>>>} */
+export const BURNED_VERSIONS = Object.freeze({
+  "11.0.0": "12.0.0",
+});
+
+export default class SkipBurnedVersions extends ConventionalChangelog {
+  /**
+   * @param {Parameters<ConventionalChangelog["getRecommendedVersion"]>[0]} options
+   * @returns {Promise<string | null>}
+   */
+  async getRecommendedVersion(options) {
+    const version = await super.getRecommendedVersion(options);
+    const skipTo =
+      typeof version === "string" ? BURNED_VERSIONS[version] : undefined;
+    if (skipTo === undefined) return version;
+    // release-it publishes its types as a bare `declare module "release-it"`,
+    // so the Plugin base class this ultimately extends is typeless and `log`
+    // doesn't exist as far as tsc can see. Same double-cast idiom as
+    // `.release-it.js` uses for the preset's typing gap.
+    const { log } =
+      /** @type {{ log: { warn: (message: string) => void } }} */ (
+        /** @type {unknown} */ (this)
+      );
+    log.warn(
+      `Computed version ${version} is burned on npm (unpublished on ` +
+        `magic-modal, occupied on react-native-magic-modal); ` +
+        `releasing ${skipTo} instead. See tools/skip-burned-versions.mjs.`,
+    );
+    return skipTo;
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -38,6 +38,9 @@
     "changelog:check": {
       "cache": false
     },
+    "release:check": {
+      "cache": false
+    },
     "typecheck": {
       "dependsOn": ["^topo", "^build"]
     },


### PR DESCRIPTION
The next breaking release computes 11.0.0, and npm can never accept that version again: it was unpublished on `magic-modal`, which burns the string forever, and it still exists deprecated on `react-native-magic-modal`, which npm refused to unpublish because the package has dependents. Every version source the pipeline reads says 10.1.1 now (tags, package.json, npm `latest`), so the bump math lands exactly on the poisoned number. Measured, not assumed: on a branch with a synthetic `feat(modal)!` commit, `release-it --release-version --ci` printed `11.0.0`. That release would tag, cut the GitHub release, and then have both publishes rejected mid-flight, leaving the repo convinced it shipped something the registry refused.

## The guard

`tools/skip-burned-versions.mjs` is the same `@release-it/conventional-changelog` plugin, subclassed, with `getRecommendedVersion` overridden to remap a burned result. The bump math stays upstream's; only `11.0.0 -> 12.0.0` is remapped, with a warning in the release log. That method is the one seam every consumer of the version sits behind, so the changelog header, the tag, the GitHub release and the npm publish all read the remapped value and cannot disagree. A check bolted onto the workflow probe instead would be a second opinion about the version, and probe/preset disagreement is exactly how 11.0.0 shipped.

It skips to 12.0.0 rather than shipping 11.0.1 as the next major: semver tooling reads 11.0.1 as a patch of an 11 line that never worked, and anyone who installed the accident and ranged `^11.0.0` would silently resolve onto a breaking release dressed as a patch. A gap in the number line costs nothing. The shim follows automatically, since `tools/release.mjs` mirrors whatever version release-it wrote, and 12.0.0 exists on neither package. Once 12.0.0 is out, `latest` sits above the stranded 11.0.0 and the shim's deprecation range can finally go back to `*` (the comment in `release.mjs` already tells that story).

`.release-it.js` now loads the plugin by absolute path because release-it resolves relative plugin paths against `process.cwd()`, and the regression check below runs this exact config from a throwaway repo in a temp dir.

## The regression check

`tools/burned-version-check.mjs`, same shape as `changelog-check.mjs`: a throwaway repo pinned to the hazard (package.json at 10.1.1, tag `magic-modal-10.1.1`, bare origin so the git plugin has an upstream), driven through the real `.release-it.js` rather than a copy of the policy. A breaking commit has to come out 12.0.0 and an ordinary fix still 10.1.2. The negative control runs the same breaking commit through the raw plugin with the same options and has to come out 11.0.0, which proves the subclass is the thing doing the work and that the underlying math still lands on the burned number. The throwaway package is private so release-it's npm plugin skips its registry and auth checks; the run is hermetic.

```
burned version check passed (breaking over 10.1.1: guarded=12.0.0, raw plugin=11.0.0; fix over 10.1.1: 10.1.2)
```

Wired into Branch Checkup as `release:check`, chained after `changelog:check`.

The `.d.ts` exists because neither release-it nor the plugin ships usable types; it declares only the class and the one method the subclass overrides.

## This PR does not release

Subject is `fix(release):` with no `(modal)` scope and no `!`, and no footer in this body, so the probe skips. The guard itself sits dormant until a real major computes 11.0.0, and the check keeps it honest until then.
