### PR TITLE
docs(readme): serve the demo hero from R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img
     alt="A rating flow moving from magicModal.show to a typed close result"
-    src="https://raw.githubusercontent.com/GSTJ/magic-modal/main/media/magic-modal-demo.gif"
+    src="https://assets.gabrieltaveira.dev/magic-modal/demo.gif"
   />
 </p>
 


### PR DESCRIPTION
📝 **DESCRIPTION:**

Last item on #338's checklist. The README hero pointed at
`raw.githubusercontent.com/GSTJ/magic-modal/main/media/magic-modal-demo.gif`
because the R2 object did not exist yet and flipping the URL early would have
put a 404 at the top of the README.

It exists now. Run
[30658205161](https://github.com/GSTJ/magic-modal/actions/runs/30658205161) of
🎬 Demo Video went green on all ten steps: the preflight reached
`portfolio-assets`, the render produced both artefacts, the upload went out with
`--remote`, and the verify step read both objects back over HTTPS and matched
sha256 against what the run had just built.

| Key | sha256 the run built | sha256 the domain serves |
| --- | --- | --- |
| `magic-modal/demo.gif` | `c3d3d1f0a6cb…` | `c3d3d1f0a6cb…` |
| `magic-modal/social.png` | `9e81ab3cc68c…` | `9e81ab3cc68c…` |

Checked again from outside CI, on the bare URL this PR actually uses:

```
$ curl -sSI https://assets.gabrieltaveira.dev/magic-modal/demo.gif
HTTP/2 200
content-type: image/gif
cache-control: public, max-age=3600
```

1685614 bytes, GIF89a, 960x540, sha256 `c3d3d1f0a6cb…` — the same object.

Bare URL, no query string. The `?ci=` suffix in the workflow's verify step is
there because Cloudflare caches responses from an R2 custom domain including the
404s from before an object existed, and it belongs in that step and nowhere else.

`media/magic-modal-demo.gif` stays committed and stays the fallback. Nothing else
in the file moved — the badges, the docs links and the copy are untouched.

🖼 **PRINTS & GIFS:**

The hero renders from the new URL right here:

<p align="center">
  <img
    alt="A rating flow moving from magicModal.show to a typed close result"
    src="https://assets.gabrieltaveira.dev/magic-modal/demo.gif"
  />
</p>

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

One line in one file. The Boy Scout Rule had nothing to pick up on the way past.

Scoped `docs` on purpose. The "Determine next version" probe in
`.github/workflows/release.yml` looks for `(modal)`-scoped commits and for
breaking-change footers, so this merges without cutting a release.

##### Awesome tests or e2e (avoid `shallow` rendering)

It is a URL in a README, so what is worth checking is that the URL resolves to
the right bytes — done above, twice: once by the workflow's own verify step
against the cache-busted URL, and once by hand against the bare URL this PR
writes.
