### PR TITLE
feat(modal): make the React Native peers optional and slim the web install to one package

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ pnpm add magic-modal
 npx expo install react-native-gesture-handler react-native-reanimated react-native-worklets react-dom react-native-web @expo/metro-runtime
 ```
 
-Read the [Expo guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/expo/) for the
-portal and web command.
+Expo Web bundles through Metro under the `react-native` condition, so it loads the native entry and
+takes the same peers as iOS and Android. The browser-only install is the Next.js one below. Read the
+[Expo guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/expo/) for the portal and web
+command.
 
 ### Expo iOS
 
@@ -78,15 +80,17 @@ iOS and Android use the same native dependency set. The
 [native guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/ios-android/) covers
 pods, Android back handling, and iOS overlays.
 
-### Next.js
+### Next.js and other browser-only React apps
 
 ```bash
-pnpm add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+pnpm add magic-modal
 ```
 
-Copy the validated alias, extension order, and Client Component setup from the
-[Next.js guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/). A runnable
-App Router consumer lives in [`examples/next-web`](examples/next-web).
+That is the whole install. The web entry ships with zero React Native dependencies, so a browser
+application needs no bundler alias and no gesture or animation peer. The native entries use the full
+React Native stack, which is why the Expo commands above install more. Copy the Client Component
+setup from the [Next.js guide](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/). A
+runnable App Router consumer lives in [`examples/next-web`](examples/next-web).
 
 For bare React Native, follow the
 [installation guide](https://magic-modal.gabrieltaveira.dev/docs/getting-started/installation/).
@@ -161,7 +165,7 @@ accessibility escape action. TypeScript exposes `data` after the caller narrows 
 ## Documentation
 
 - [Expo Web, iOS, and Android](https://magic-modal.gabrieltaveira.dev/docs/platforms/expo/)
-- [Next.js and React Native Web](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/)
+- [Next.js and web](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/)
 - [Modal flows and stacks](https://magic-modal.gabrieltaveira.dev/docs/guides/modal-flows/)
 - [Hide results](https://magic-modal.gabrieltaveira.dev/docs/reference/hide-results/)
 - [Accessibility](https://magic-modal.gabrieltaveira.dev/docs/guides/accessibility/)

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -3,9 +3,11 @@ title: Installation
 description: Install the packages required by your target runtime.
 ---
 
-Choose the runtime the application ships. Expo Web uses browser packages. Expo iOS and Android use
-the same native dependency set. A project that ships several targets installs the union of those
-sets.
+Choose the runtime the application ships. A browser-only application installs `magic-modal` and
+nothing else: the web entry ships with zero React Native dependencies. Expo and bare React Native
+load the native entry, which uses the full React Native stack, so those targets install the peer set
+below. Expo Web counts as native here — it bundles through Metro under the `react-native` condition.
+A project that ships several targets installs the union of those sets.
 
 <Cards>
   <Card
@@ -25,7 +27,7 @@ sets.
   />
   <Card
     title="Next.js"
-    description="Configure React Native Web in an App Router application."
+    description="Add the portal to an App Router application. No bundler configuration."
     href="/docs/platforms/nextjs"
   />
 </Cards>
@@ -105,43 +107,48 @@ match because both targets load the native package entry.
 Expo's Babel preset configures Worklets. A default Expo project does not need another Babel plugin
 entry.
 
-## Next.js
+## Next.js and other browser-only React apps
 
-React and React DOM come with Next.js. Add Magic Modal and its browser runtime:
+React and React DOM come with Next.js. Add Magic Modal:
 
 <Tabs groupId="package-manager" items={["pnpm", "npm", "Yarn", "Bun"]} persist>
   <Tab value="pnpm">
 
 ```bash
-pnpm add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+pnpm add magic-modal
 ```
 
   </Tab>
   <Tab value="npm">
 
 ```bash
-npm install magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+npm install magic-modal
 ```
 
   </Tab>
   <Tab value="Yarn">
 
 ```bash
-yarn add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+yarn add magic-modal
 ```
 
   </Tab>
   <Tab value="Bun">
 
 ```bash
-bun add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+bun add magic-modal
 ```
 
   </Tab>
 </Tabs>
 
-The [Next.js guide](/docs/platforms/nextjs) contains the validated Turbopack alias, extension order,
-transpilation list, and Client Component root.
+That is the whole install, and it is the same one for a plain React or Vite application: add
+`react` and `react-dom` yourself if the framework does not already bring them. There is no bundler
+configuration, no `react-native-web`, and no gesture or animation peer, because the browser entry
+renders DOM elements and imports nothing but `react`.
+
+The [Next.js guide](/docs/platforms/nextjs) covers the Client Component root and the browser
+behavior.
 
 ## Bare React Native
 

--- a/apps/docs/content/docs/getting-started/setup.mdx
+++ b/apps/docs/content/docs/getting-started/setup.mdx
@@ -56,7 +56,7 @@ The portal stays the same. Its root file and bundler setup depend on the runtime
 <Cards>
   <Card
     title="Next.js and web"
-    description="Add the portal to a Client Component and map React Native to React Native Web."
+    description="Add the portal to a Client Component. No bundler configuration and no React Native peers."
     href="/docs/platforms/nextjs"
   />
   <Card

--- a/apps/docs/content/docs/platforms/expo.mdx
+++ b/apps/docs/content/docs/platforms/expo.mdx
@@ -54,7 +54,9 @@ npx expo start --web
 ```
 
 This path keeps the same React Native component and `HideReturn<T>` contract used by the native
-targets.
+targets. Expo Web bundles through Metro under the `react-native` condition, so it loads the native
+entry and takes the full peer set even though it runs in a browser. The
+[Next.js guide](/docs/platforms/nextjs) covers the browser-only entry, which needs none of them.
 
 ## Expo iOS
 

--- a/apps/docs/content/docs/platforms/nextjs.mdx
+++ b/apps/docs/content/docs/platforms/nextjs.mdx
@@ -1,90 +1,77 @@
 ---
 title: Next.js and web
-description: Run Magic Modal in a Next.js App Router application with React Native Web.
+description: Run Magic Modal in a Next.js App Router application.
 ---
 
-Magic Modal runs in the browser through React Native Web. Mount one portal in a Client Component,
-call `show()` from an event or effect, and await the same `HideReturn<T>` contract used by Expo.
+The browser entry renders plain DOM elements and imports nothing but `react`. Mount one portal in a
+Client Component, call `show()` from an event or effect, and await the same `HideReturn<T>` contract
+used by Expo.
 
 This guide targets the App Router with Next.js 16 and Turbopack. The repository fixture builds the
 published package boundary, hydrates it in Chrome, opens a modal, and verifies backdrop dismissal.
 
 ## Install
 
-React and React DOM already come with a Next.js application. Add Magic Modal and its runtime peers:
+React and React DOM already come with a Next.js application. Add Magic Modal:
 
 <Tabs groupId="package-manager" items={["pnpm", "npm", "Yarn", "Bun"]} persist>
   <Tab value="pnpm">
 
 ```bash
-pnpm add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+pnpm add magic-modal
 ```
 
   </Tab>
   <Tab value="npm">
 
 ```bash
-npm install magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+npm install magic-modal
 ```
 
   </Tab>
   <Tab value="Yarn">
 
 ```bash
-yarn add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+yarn add magic-modal
 ```
 
   </Tab>
   <Tab value="Bun">
 
 ```bash
-bun add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets
+bun add magic-modal
 ```
 
   </Tab>
 </Tabs>
 
-`react-native` supplies package types and peer resolution. The browser bundle resolves its component
-imports to `react-native-web`.
+That is the whole install. The web entry ships with zero React Native dependencies, so a browser
+application needs neither `react-native` nor `react-native-web`. The native entries still use the
+full React Native stack, and every React Native peer is optional in the manifest for exactly that
+reason.
 
 ## Configure Next.js
 
-Transpile the React Native packages. Resolve `.web` files before their native counterparts and map
-`react-native` to `react-native-web`:
+Nothing to configure. `next.config.ts` needs no `transpilePackages`, no `resolveAlias`, and no
+`.web.*` entry in `resolveExtensions` for Magic Modal:
 
 ```ts title="next.config.ts"
 import type { NextConfig } from "next";
 
 const config = {
   reactStrictMode: true,
-  transpilePackages: [
-    "react-native-gesture-handler",
-    "react-native-reanimated",
-  ],
-  turbopack: {
-    resolveAlias: {
-      "react-native": "react-native-web",
-    },
-    resolveExtensions: [
-      ".web.tsx",
-      ".web.ts",
-      ".web.jsx",
-      ".web.js",
-      ".web.mjs",
-      ".web.cjs",
-      ".tsx",
-      ".ts",
-      ".jsx",
-      ".js",
-      ".mjs",
-      ".cjs",
-      ".json",
-    ],
-  },
 } satisfies NextConfig;
 
 export default config;
 ```
+
+<Callout type="info" title="Upgrading from a React Native Web setup">
+  Earlier versions rendered through React Native Web and this guide shipped an
+  alias, an extension order, and a transpile list to make that work. Delete
+  those entries along with `react-native`, `react-native-web`,
+  `react-native-gesture-handler`, `react-native-reanimated`, and
+  `react-native-worklets` if nothing else in the application uses them.
+</Callout>
 
 The matching repository fixture is `examples/next-web`.
 
@@ -130,8 +117,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 Mount one `MagicModalPortal` for the whole application. Calls made before the shell mounts throw a
 `MagicModalPortal not found` error.
 
-Gesture Handler runs without `GestureHandlerRootView` on web. Shared Expo/native layouts keep the
-gesture root.
+There is no `GestureHandlerRootView` here, because there is no Gesture Handler in the browser bundle.
+Shared Expo and native layouts still keep the gesture root.
 
 ## Open a modal
 
@@ -262,11 +249,6 @@ Read [Accessibility](/docs/guides/accessibility) for focus order, explicit close
 modals, and test coverage.
 
 ## Troubleshooting
-
-### Next cannot resolve `react-native`
-
-Install both `react-native` and `react-native-web`. Copy the `resolveAlias` and `resolveExtensions`
-entries from this guide. Restart the Next.js development server.
 
 ### A server component imports the modal
 

--- a/apps/docs/content/docs/resources.mdx
+++ b/apps/docs/content/docs/resources.mdx
@@ -12,7 +12,7 @@ description: Examples, releases, contributing guidance, and support for Magic Mo
   />
   <Card
     title="Next.js consumer"
-    description="A tested App Router consumer with React Native Web, server rendering, hydration, and backdrop dismissal."
+    description="A tested App Router consumer with server rendering, hydration, and backdrop dismissal."
     href="https://github.com/GSTJ/magic-modal/tree/main/examples/next-web"
     external
   />

--- a/examples/next-web/README.md
+++ b/examples/next-web/README.md
@@ -15,10 +15,9 @@ pnpm --filter @magic-modal/next-web smoke:browser
 The smoke check starts the production build in headless Chrome. It clicks the open button and the
 backdrop and expects `BACKDROP_PRESS`.
 
-The dependency list in `package.json` is the complete Next.js browser runtime.
-`react-native-web` provides the browser implementation for React Native primitives. Turbopack
-aliases `react-native` to that package and transpiles Gesture Handler and Reanimated so their `.web`
-files win resolution.
+The dependency list in `package.json` is the complete Next.js browser runtime: `magic-modal`,
+`next`, `react`, and `react-dom`. No `react-native`, no `react-native-web`, and no gesture or
+animation package, because the browser entry renders DOM elements and imports nothing but `react`.
+`next.config.ts` is bare for the same reason.
 
-The portal lives in a Client Component. The fixture mounts it directly because Gesture Handler skips
-the root-view check in the browser.
+The portal lives in a Client Component. The fixture mounts it directly, with no gesture root view.

--- a/examples/next-web/next.config.ts
+++ b/examples/next-web/next.config.ts
@@ -1,28 +1,11 @@
 import type { NextConfig } from "next";
 
+// Deliberately bare. The browser entry renders DOM elements and imports nothing
+// but `react`, so no alias, no `.web.*` extension order, and no transpile list
+// holds this fixture up. If any of that has to come back, the package
+// regressed.
 const config = {
   reactStrictMode: true,
-  transpilePackages: ["react-native-gesture-handler", "react-native-reanimated"],
-  turbopack: {
-    resolveAlias: {
-      "react-native": "react-native-web",
-    },
-    resolveExtensions: [
-      ".web.tsx",
-      ".web.ts",
-      ".web.jsx",
-      ".web.js",
-      ".web.mjs",
-      ".web.cjs",
-      ".tsx",
-      ".ts",
-      ".jsx",
-      ".js",
-      ".mjs",
-      ".cjs",
-      ".json",
-    ],
-  },
 } satisfies NextConfig;
 
 export default config;

--- a/examples/next-web/package.json
+++ b/examples/next-web/package.json
@@ -12,12 +12,7 @@
     "magic-modal": "workspace:*",
     "next": "16.2.12",
     "react": "19.2.0",
-    "react-dom": "19.2.0",
-    "react-native": "0.83.10",
-    "react-native-gesture-handler": "3.1.0",
-    "react-native-reanimated": "4.2.3",
-    "react-native-web": "0.21.2",
-    "react-native-worklets": "0.7.4"
+    "react-dom": "19.2.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -115,7 +115,19 @@
     "react-native-worklets": ">=0.5.0"
   },
   "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "react-native-gesture-handler": {
+      "optional": true
+    },
+    "react-native-reanimated": {
+      "optional": true
+    },
     "react-native-screens": {
+      "optional": true
+    },
+    "react-native-worklets": {
       "optional": true
     }
   }

--- a/packages/modal/tools/check-web-build.mjs
+++ b/packages/modal/tools/check-web-build.mjs
@@ -237,10 +237,28 @@ if (
   );
 }
 
-if (!packageJSON.peerDependenciesMeta["react-native-screens"].optional) {
-  throw new Error(
-    "react-native-screens must stay optional for browser-only consumers.",
-  );
+// Every React Native peer has to stay optional. The browser entry imports none
+// of them, so a web-only install should not be warned about them or have npm
+// pull them in — with a pinned react, npm resolving react-native as a required
+// peer is an outright ERESOLVE. Native consumers are unaffected: the React
+// Native entry imports each one statically, so a missing package is a Metro
+// bundling error, not a silent degrade.
+const nativePeers = Object.keys(packageJSON.peerDependencies).filter(
+  (packageName) => nativeOnlyPackages.includes(packageName),
+);
+
+for (const packageName of nativePeers) {
+  if (!packageJSON.peerDependenciesMeta[packageName]?.optional) {
+    throw new Error(
+      `${packageName} must stay optional in peerDependenciesMeta for browser-only consumers.`,
+    );
+  }
+}
+
+// The other half of the same rule: react is the one peer the browser entry does
+// import, so it stays required.
+if (packageJSON.peerDependenciesMeta.react) {
+  throw new Error("react is a required peer of the browser entry.");
 }
 
 console.log(
@@ -250,3 +268,6 @@ console.log(
   `✓ Web bundle: ${formatBytes(minified)} minified, ${formatBytes(gzip)} gzipped (budget ${formatBytes(gzipBudgetInBytes)}), identical without the react-native alias`,
 );
 console.log("✓ Web SSR: the portal and its stylesheet render without a DOM");
+console.log(
+  `✓ Web peers: react is required, ${nativePeers.join(", ")} are optional`,
+);

--- a/packages/react-native-magic-modal/package.json
+++ b/packages/react-native-magic-modal/package.json
@@ -89,7 +89,19 @@
     "react-native-worklets": ">=0.5.0"
   },
   "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "react-native-gesture-handler": {
+      "optional": true
+    },
+    "react-native-reanimated": {
+      "optional": true
+    },
     "react-native-screens": {
+      "optional": true
+    },
+    "react-native-worklets": {
       "optional": true
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,21 +267,6 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
-      react-native:
-        specifier: 0.83.10
-        version: 0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      react-native-gesture-handler:
-        specifier: 3.1.0
-        version: 3.1.0(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-      react-native-reanimated:
-        specifier: 4.2.3
-        version: 4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-      react-native-web:
-        specifier: 0.21.2
-        version: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react-native-worklets:
-        specifier: 0.7.4
-        version: 0.7.4(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)
     devDependencies:
       '@types/node':
         specifier: ^26.1.1


### PR DESCRIPTION
A Next.js install goes from `pnpm add magic-modal react-native react-native-web react-native-gesture-handler react-native-reanimated react-native-worklets` plus a Turbopack alias, an extension order and a transpile list, to `pnpm add magic-modal`.

The code has been that way since the DOM rewrite in 10.1. `dist/index.js` imports `react` and nothing else. `check-web-build.mjs` asserts the browser bundle names no React Native package, and that it gzips to the same 5.4 KB with and without the `react-native` to `react-native-web` alias. The manifest and the docs still asked every web consumer for the full stack.

## Peer dependencies

`react-native`, `react-native-gesture-handler`, `react-native-reanimated` and `react-native-worklets` join `react-native-screens` in `peerDependenciesMeta`. `react` stays required, since it is the one peer the browser entry imports.

Web-only consumers stop getting warnings and auto-installs for packages that never reach their bundle. With react pinned to an exact version, npm resolved `react-native` as a required peer and then failed on react-native's own react range:

```
npm error Found: react@19.2.0
npm error   peer react@">=18.0.0" from magic-modal@10.1.1
npm error Could not resolve dependency:
npm error peer react@"^19.2.3" from react-native@0.86.2
npm error   peer react-native@">=0.81.0" from magic-modal@10.1.1
```

Native consumers already install this set, because the Expo and bare React Native docs say to, and the native entry imports every one of them statically:

```
$ grep -oE "^import .*from '[^']+'" dist/index.react-native.runtime.js
'react'
'react-native'
'react-native-gesture-handler'
'react-native-reanimated'
'react-native-screens'
'react-native-worklets'
```

A missing package is a Metro resolution error at bundle time, before the app starts. Optional in the manifest only tells the package manager to stop installing them unprompted.

`check-web-build.mjs` now asserts the whole set instead of just `react-native-screens`, plus that `react` stays required. The shim mirrors the manifest through `sync-manifest.mjs --write`, and `--check` passes.

## Scratch installs

Two scratch directories, react pinned exact, installing the tarball packed from this branch against one packed from `main`. The dist is identical in both; the manifests differ.

| | npm 11.16 | pnpm 11.17 |
| --- | --- | --- |
| main | ERESOLVE, nothing installed | 302 packages, peer warnings, `react-native@0.86.2` pulled in |
| this branch | `added 4 packages in 780ms` | `Packages: +4`, no warnings |

```
$ npm ls
scratch-web-consumer@1.0.0
├── magic-modal@10.1.1
├── react-dom@19.2.0
└── react@19.2.0

$ node --input-type=module -e "import * as m from 'magic-modal'; console.log(Object.keys(m))"
[ 'MagicModalHideReason', 'MagicModalPortal', 'magicModal', 'useMagicModal' ]
```

`npm ls` lists the five as `UNMET OPTIONAL DEPENDENCY`, and the install exits clean.

## Docs

- `platforms/nextjs.mdx`. Install is `pnpm add magic-modal` across all four tabs. The `Configure Next.js` section keeps its heading and says there is nothing to configure, with the bare `next.config.ts` and a callout listing what an upgrading project should delete. The `Next cannot resolve react-native` troubleshooting entry is gone. The Gesture Handler note now says the browser bundle contains no Gesture Handler.
- `getting-started/installation.mdx`. The Next.js section covers plain React and Vite too, since the answer is identical there.
- `getting-started/setup.mdx` and `resources.mdx`. Card descriptions that promised React Native Web.
- `README.md`. Same treatment for the Next.js block.

Wherever the two entries could be confused, the docs state in one line that the web entry ships with zero React Native dependencies and the native entries use the full stack.

The landing page needed nothing. `InstallCommand` already rendered `pnpm add magic-modal`.

## Expo

Unchanged, deliberately. Expo Web bundles through Metro under the `react-native` condition, so it resolves the `react-native` export and loads the native entry, peers included. `platforms/expo.mdx`, the Expo sections of `installation.mdx`, `platforms/ios-android.mdx` and the README's Expo Web block keep their full peer set. expo.mdx and the README each gained a sentence saying why, pointing at the Next.js guide for the browser-only case.

## examples/next-web

Slimmed. `react-native`, `react-native-web`, `react-native-gesture-handler`, `react-native-reanimated` and `react-native-worklets` are out of its dependencies. `transpilePackages`, `resolveAlias` and `resolveExtensions` are out of `next.config.ts`, which is now four lines. `next build`, `tsc --noEmit` and the browser smoke pass, and no client chunk mentions `react-native-web`.

Its lockfile diff is 15 deletions.

## Validation

```
pnpm build           4 tasks, includes the docs static export
pnpm typecheck       6 tasks
pnpm test            9 suites, 127 tests
pnpm format          5 tasks, all matched files use the correct format
pnpm changelog:check preset, note pattern and negative control all passed
pnpm doctor          all checks passed
oxlint               run directly per package, 0 errors
```

The modal build guards, in full:

```
✓ Web package boundary: runtime guard loads first, browser omits react-native, react-native-web, react-native-gesture-handler, react-native-reanimated, react-native-screens, react-native-worklets
✓ Web bundle: 14.2 KB minified, 5.4 KB gzipped (budget 6.6 KB), identical without the react-native alias
✓ Web SSR: the portal and its stylesheet render without a DOM
✓ Web peers: react is required, react-native, react-native-gesture-handler, react-native-reanimated, react-native-screens, react-native-worklets are optional
```

```
$ pnpm --filter @magic-modal/next-web smoke:browser
✓ Next.js browser smoke: dialog semantics, stack isolation, focus, Escape, backdrop, and swipe dismissal
```

Bump computed with the repo's own preset and tag prefix: `minor`, 0 breaking changes and 1 feature, so 10.1.1 to 10.2.0.

`apps/docs` still carries the React Native packages and the Turbopack alias in its own config. Nothing in it imports them either. That config only affects the docs site itself, so I left it for a separate PR.
