### PR TITLE
chore(docs): drop the React Native stack the docs app no longer imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,11 @@ export default function App() {
 }
 ```
 
-With Expo Router, put the same structure in the root `app/_layout.tsx`. Next.js mounts the portal
-inside a Client Component as shown in the [web setup](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/).
+With Expo Router, put the same structure in the root `app/_layout.tsx`.
+
+A browser application mounts `MagicModalPortal` inside a Client Component and nothing else. There is
+no `GestureHandlerRootView`, because there is no Gesture Handler in the browser bundle. Copy the
+shell from the [web setup](https://magic-modal.gabrieltaveira.dev/docs/platforms/nextjs/).
 
 ## Return typed data
 
@@ -156,6 +159,10 @@ export async function confirmRelease() {
   return result.data;
 }
 ```
+
+That modal is the React Native one. The browser entry renders DOM, so the same modal on the web is a
+`<section>` with `<h2>` and `<button>` and imports nothing from React Native. The result contract is
+identical either way.
 
 Backdrop presses, completed swipes, system-dismiss actions, and `hideAll()` resolve the same promise
 with distinct reasons. System dismissal includes Android back, web Escape, and the native
@@ -218,4 +225,4 @@ and read the [contributing guide](CONTRIBUTING.md).
 
 ## License
 
-React Native Magic Modal is licensed under the [MIT License](LICENSE).
+Magic Modal is licensed under the [MIT License](LICENSE).

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -8,30 +8,6 @@ import { site } from "./lib/site";
 const config = {
   ...createMagicDocsStaticExport(site),
   reactStrictMode: true,
-  transpilePackages: [
-    "react-native-gesture-handler",
-    "react-native-reanimated",
-  ],
-  turbopack: {
-    resolveAlias: {
-      "react-native": "react-native-web",
-    },
-    resolveExtensions: [
-      ".web.tsx",
-      ".web.ts",
-      ".web.jsx",
-      ".web.js",
-      ".web.mjs",
-      ".web.cjs",
-      ".tsx",
-      ".ts",
-      ".jsx",
-      ".js",
-      ".mjs",
-      ".cjs",
-      ".json",
-    ],
-  },
 } satisfies NextConfig;
 
 export default createMDX()(config);

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,11 +31,6 @@
     "next": "16.2.12",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.10",
-    "react-native-gesture-handler": "3.1.0",
-    "react-native-reanimated": "4.2.3",
-    "react-native-web": "0.21.2",
-    "react-native-worklets": "0.7.4",
     "server-only": "0.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,21 +115,6 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
-      react-native:
-        specifier: 0.83.10
-        version: 0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      react-native-gesture-handler:
-        specifier: 3.1.0
-        version: 3.1.0(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-      react-native-reanimated:
-        specifier: 4.2.3
-        version: 4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-      react-native-web:
-        specifier: 0.21.2
-        version: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react-native-worklets:
-        specifier: 0.7.4
-        version: 0.7.4(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)
       server-only:
         specifier: 0.0.1
         version: 0.0.1


### PR DESCRIPTION
The follow-up #349 called out: `apps/docs` still carried the React Native
packages and the Turbopack alias in its own config, and nothing in it imported
them.

## The docs app

Removed from `apps/docs/package.json`: `react-native`, `react-native-web`,
`react-native-gesture-handler`, `react-native-reanimated`,
`react-native-worklets`.

Removed from `apps/docs/next.config.ts`: the `transpilePackages` list (which
held only Gesture Handler and Reanimated), the Turbopack `react-native` to
`react-native-web` `resolveAlias`, and the `.web.*` `resolveExtensions` order.
What is left is the static export, `createMDX()` and `reactStrictMode`.

### Grep proof

Every package name, searched across all 77 tracked files under `apps/docs`,
excluding the two files this PR edits:

```
$ for p in react-native react-native-web react-native-gesture-handler \
           react-native-reanimated react-native-worklets; do
    git grep -n -- "$p" -- apps/docs \
      | grep -v '^apps/docs/package.json' \
      | grep -v '^apps/docs/next.config.ts'
  done
```

Everything it returns is either a fenced code block in `content/docs` or prose
about what a *consumer* installs. Nothing under `app/`, `components/`, `lib/`,
`scripts/` or `test/` matches at all — the single hit outside `content/` is a
`dev.to` article URL on the landing page.

The `import` lines that MDX would compile if they sat at the top level are all
inside fences:

```
$ awk '/^```/{inf=!inf; next} /react-native/{printf "line %d fence=%s\n", NR, (inf?"INSIDE":"TOPLEVEL")}' <file>

first-modal.mdx        line 9   INSIDE
setup.mdx              line 12  INSIDE
setup.mdx              line 34  INSIDE
accessibility.mdx      line 28  INSIDE
recipes.mdx            line 30  INSIDE
expo.mdx               line 106 INSIDE
expo.mdx               line 133 INSIDE
use-magic-modal.mdx    line 24  INSIDE
```

The only `TOPLEVEL` hits are prose sentences with inline backticks.

`resolveExtensions` was safe to drop for the same reason: the one `.web.*` file
in the repository is `packages/modal/src/components/magic-modal.browser.web.test.tsx`,
which the docs site never resolves.

Lockfile diff is 15 deletions, all inside the `apps/docs` importer.

## README audit

The Next.js install block was already slimmed. Three things it missed.

**Mount the portal.** The Expo sentence and the web sentence shared a paragraph,
so the only structure a web reader saw was one wrapped in
`GestureHandlerRootView`:

> With Expo Router, put the same structure in the root `app/_layout.tsx`. Next.js mounts the portal
> inside a Client Component as shown in the [web setup](…).

Now:

> With Expo Router, put the same structure in the root `app/_layout.tsx`.
>
> A browser application mounts `MagicModalPortal` inside a Client Component and nothing else. There is
> no `GestureHandlerRootView`, because there is no Gesture Handler in the browser bundle. Copy the
> shell from the [web setup](…).

That is the same claim `platforms/nextjs.mdx` already makes. The Expo code block
above it is unchanged and still wraps in the gesture root.

**Return typed data.** The README's one worked example imports `Pressable`,
`Text` and `View` from `react-native`, under a platform-neutral heading, with
nothing marking it as the native version. Added after the block:

> That modal is the React Native one. The browser entry renders DOM, so the same modal on the web is a
> `<section>` with `<h2>` and `<button>` and imports nothing from React Native. The result contract is
> identical either way.

**Licence.** `React Native Magic Modal is licensed under the MIT License.` to
`Magic Modal is licensed under the MIT License.` — stale since the rename. This
file is what `copy:readme` publishes to npm.

Checked and left alone: the Expo Web block and its explanatory sentence (Metro
bundles under the `react-native` condition, so it loads the native entry and
takes the same peers), the Expo iOS/Android blocks, the "Next.js and other
browser-only React apps" block, both documentation link titles, and the badges.
The FAQ's `ScrollView` entry is worded identically on the docs site, so changing
one and not the other would only add drift; it is about gesture conflicts, not
about what a web app installs.

## Validation

```
pnpm build           4 tasks, docs static export included
pnpm typecheck       6 tasks
pnpm test            9 suites, 127 tests
pnpm format          5 tasks, all matched files use the correct format
pnpm changelog:check preset, note pattern and negative control all passed
pnpm doctor          all checks passed
oxlint               run directly per package, 0 errors
```

The modal build guards, in full:

```
✓ Web package boundary: runtime guard loads first, browser omits react-native, react-native-web, react-native-gesture-handler, react-native-reanimated, react-native-screens, react-native-worklets
✓ Web bundle: 14.2 KB minified, 5.4 KB gzipped (budget 6.6 KB), identical without the react-native alias
✓ Web SSR: the portal and its stylesheet render without a DOM
✓ Web peers: react is required, react-native, react-native-gesture-handler, react-native-reanimated, react-native-screens, react-native-worklets are optional
```

The docs export link checker, which is the thing this PR could plausibly break:

```
✓ Docs artifact: 24 required files, 37 HTML files, 828 internal links
```

`oxlint` was run from the package directories rather than through `turbo`, and
verified to be a real green: planting a `no-self-compare` and a `no-debugger`
violation in `apps/docs` makes the same full-directory invocation exit 1 with
both diagnostics.

No release: both commits are `chore` and `docs`, which the preset bumps to
`null`.
