### PR TITLE
build(examples): give next-web the house formatter config

### DIFF
--- a/examples/next-web/app/layout.tsx
+++ b/examples/next-web/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+
+import type { Metadata } from "next";
 
 import "./styles.css";
 

--- a/examples/next-web/app/modal-demo.tsx
+++ b/examples/next-web/app/modal-demo.tsx
@@ -3,6 +3,7 @@
 import type { HideReturn } from "magic-modal";
 
 import { useState } from "react";
+
 import {
   MagicModalHideReason,
   MagicModalPortal,
@@ -34,7 +35,11 @@ const ConfirmationModal = () => {
       <p className="eyebrow">UNIVERSAL FLOW</p>
       <h2 id="fixture-modal-title">Ship the web build?</h2>
       <p>The same promise contract is available on web, iOS, and Android.</p>
-      <button data-testid="confirm-modal" onClick={() => hide({ confirmed: true })} type="button">
+      <button
+        data-testid="confirm-modal"
+        onClick={() => hide({ confirmed: true })}
+        type="button"
+      >
         Confirm
       </button>
       <button
@@ -99,7 +104,11 @@ export const ModalDemo = () => {
       <button data-testid="open-modal" onClick={open} type="button">
         Open modal
       </button>
-      <button data-testid="open-swipeable" onClick={openSwipeable} type="button">
+      <button
+        data-testid="open-swipeable"
+        onClick={openSwipeable}
+        type="button"
+      >
         Open swipeable modal
       </button>
       <output data-testid="modal-result">{result}</output>

--- a/examples/next-web/app/page.tsx
+++ b/examples/next-web/app/page.tsx
@@ -6,8 +6,8 @@ export default function Home() {
       <p className="eyebrow">REAL NEXT.JS CONSUMER</p>
       <h1>One modal API, including the web.</h1>
       <p className="intro">
-        This fixture imports the built npm package, renders its portal, and resolves a backdrop
-        dismissal in a Client Component.
+        This fixture imports the built npm package, renders its portal, and
+        resolves a backdrop dismissal in a Client Component.
       </p>
       <ModalDemo />
     </main>

--- a/examples/next-web/oxfmt.config.mts
+++ b/examples/next-web/oxfmt.config.mts
@@ -1,0 +1,1 @@
+export { next as default } from "magic-oxfmt-config";

--- a/examples/next-web/package.json
+++ b/examples/next-web/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "format": "oxfmt --check .",
+    "format:fix": "oxfmt .",
     "smoke:browser": "node tools/browser-smoke.mjs",
     "start": "next start",
     "typecheck": "tsc --noEmit"
@@ -18,6 +20,8 @@
     "@types/node": "^26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "magic-oxfmt-config": "^1.2.0",
+    "oxfmt": "0.60.0",
     "typescript": "^5.7.2"
   }
 }

--- a/examples/next-web/tools/browser-smoke.mjs
+++ b/examples/next-web/tools/browser-smoke.mjs
@@ -1,8 +1,8 @@
+import { spawn } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawn } from "node:child_process";
 
 const host = "127.0.0.1";
 
@@ -64,7 +64,9 @@ const findChrome = async () => {
     }
   }
 
-  throw new Error("Chrome was not found. Set CHROME_BIN to run the browser smoke check.");
+  throw new Error(
+    "Chrome was not found. Set CHROME_BIN to run the browser smoke check.",
+  );
 };
 
 const connectDevTools = async (url) => {
@@ -193,7 +195,10 @@ try {
     return true;
   })()`);
   await waitFor(
-    () => evaluate(`document.querySelector('[data-testid="modal-result"]').textContent === "OPEN"`),
+    () =>
+      evaluate(
+        `document.querySelector('[data-testid="modal-result"]').textContent === "OPEN"`,
+      ),
     "the click handler",
   );
   await waitFor(
@@ -219,7 +224,9 @@ try {
     modalSemantics.label !== "Ship the web build?" ||
     modalSemantics.modal !== "true"
   ) {
-    throw new Error(`Unexpected modal semantics: ${JSON.stringify(modalSemantics)}`);
+    throw new Error(
+      `Unexpected modal semantics: ${JSON.stringify(modalSemantics)}`,
+    );
   }
 
   await waitFor(
@@ -249,7 +256,9 @@ try {
   })()`);
   await waitFor(
     () =>
-      evaluate(`document.querySelectorAll('[data-testid="magic-modal-stack-entry"]').length === 2`),
+      evaluate(
+        `document.querySelectorAll('[data-testid="magic-modal-stack-entry"]').length === 2`,
+      ),
     "the nested stack entry",
   );
 
@@ -273,12 +282,16 @@ try {
     stackSemantics.label !== "One more check" ||
     stackSemantics.topHidden !== null
   ) {
-    throw new Error(`Unexpected stack semantics: ${JSON.stringify(stackSemantics)}`);
+    throw new Error(
+      `Unexpected stack semantics: ${JSON.stringify(stackSemantics)}`,
+    );
   }
 
   await waitFor(
     () =>
-      evaluate(`document.activeElement === document.querySelector('[data-testid="close-nested"]')`),
+      evaluate(
+        `document.activeElement === document.querySelector('[data-testid="close-nested"]')`,
+      ),
     "focus in the nested stack entry",
   );
 
@@ -339,7 +352,9 @@ try {
     "the Escape dismissal and restored focus",
   );
 
-  await evaluate(`document.querySelector('[data-testid="open-modal"]').click(); true`);
+  await evaluate(
+    `document.querySelector('[data-testid="open-modal"]').click(); true`,
+  );
   await waitFor(
     () =>
       evaluate(
@@ -347,7 +362,9 @@ try {
       ),
     "the second modal",
   );
-  await evaluate(`document.querySelector('[data-testid="magic-modal-backdrop"]').click(); true`);
+  await evaluate(
+    `document.querySelector('[data-testid="magic-modal-backdrop"]').click(); true`,
+  );
   await waitFor(
     () =>
       evaluate(
@@ -362,9 +379,14 @@ try {
   // and decides on release velocity, so it needs a real event stream with real
   // timestamps — `Input.dispatchMouseEvent` produces exactly that, and Chrome
   // synthesises the pointer events from it the same way a mouse would.
-  await evaluate(`document.querySelector('[data-testid="open-swipeable"]').click(); true`);
+  await evaluate(
+    `document.querySelector('[data-testid="open-swipeable"]').click(); true`,
+  );
   await waitFor(
-    () => evaluate(`Boolean(document.querySelector('[data-testid="swipeable-body"]'))`),
+    () =>
+      evaluate(
+        `Boolean(document.querySelector('[data-testid="swipeable-body"]'))`,
+      ),
     "the swipeable modal",
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,12 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      magic-oxfmt-config:
+        specifier: ^1.2.0
+        version: 1.2.0(oxfmt@0.60.0)
+      oxfmt:
+        specifier: 0.60.0
+        version: 0.60.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3


### PR DESCRIPTION
`examples/next-web` was the one workspace package with no `oxfmt.config.mts`
and no `format` script. Both halves of that mattered.

## The config

oxfmt says so itself when you run it there on `main`:

```
$ cd examples/next-web && oxfmt --check .
Checking formatting...

app/modal-demo.tsx (6ms)
tools/browser-smoke.mjs (6ms)

Format issues found in above 2 files. Run without `--check` to fix.
No config found, using defaults.
```

oxfmt's defaults are not the house style. `printWidth` is 100 against our 80,
there is no import sorting, and none of the shared `ignorePatterns` apply. So
the check that was not running would also have been checking the wrong thing.

The file is the same one line as `apps/docs`:

```ts
export { next as default } from "magic-oxfmt-config";
```

`next` is the right preset. Reading `magic-oxfmt-config`'s exports — `base`,
`react`, `next`, `reactNative`, `expo` — `next` is `base` plus `**/out/**` and
`**/next-env.d.ts` in `ignorePatterns`, and next-web tracks a `next-env.d.ts`.
`react` would leave that file to be reformatted on every `next build` that
regenerates it.

## The task

`format` and `format:fix` are wired the same way the other five packages wire
them (`oxfmt --check .` / `oxfmt .`). turbo.json already declares both tasks
with no `dependsOn` and no filter, so turbo picks the scripts up per package —
no turbo.json change is needed, and none is in this PR.

Root `pnpm format` before and after:

```
before   Tasks: 5 successful, 5 total
after    Tasks: 6 successful, 6 total
                @magic-modal/next-web:format: All matched files use the correct format.
                @magic-modal/next-web:format: Finished in 126ms on 10 files using 10 threads.
```

## The reformat

With the config in place, four files drift rather than two:

```
app/layout.tsx
app/modal-demo.tsx
app/page.tsx
tools/browser-smoke.mjs
```

Separate commit (`style(examples): apply the house format to next-web`) so the
config commit stays readable. It is 48 insertions and 16 deletions and all of
it is mechanical:

- reflow at 80 columns instead of 100 — JSX attributes onto their own lines,
  long `evaluate()` template literals and `throw new Error(...)` arguments
  wrapped
- `app/layout.tsx`: the `next` type import moves below the `react` one, per the
  shared group order (`type`, `react-type`, `next-type`, …)
- `tools/browser-smoke.mjs`: `node:child_process` sorts up to the top of the
  builtins

No expression, argument, or string literal changed.

## Validation

Formatting must not break the app, so the fixture's own checks ran on the
reformatted tree:

```
$ pnpm --filter @magic-modal/next-web build
✓ Compiled successfully in 1325ms
  Finished TypeScript in 968ms
✓ Generating static pages using 4 workers (3/3) in 184ms

$ pnpm --filter @magic-modal/next-web smoke:browser
✓ Next.js browser smoke: dialog semantics, stack isolation, focus, Escape, backdrop, and swipe dismissal
```

Root suite:

```
pnpm build           4 tasks
pnpm typecheck       6 tasks
pnpm test            9 suites, 127 tests
pnpm format          6 tasks, next-web included, all matched files use the correct format
pnpm changelog:check preset, note pattern and negative control all passed
oxlint               run directly per package, 0 errors
```

No release: `build` bumps to `null` under the preset and `style` is hidden from
the changelog entirely.
