### PR TITLE
fix(deps): patch security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,9 @@ overrides:
   undici: ^8.0.0
   lodash: ^4.18.0
   tmp: ^0.2.6
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
+  fast-uri: ^3.1.5
+  hono: ^4.12.34
   uuid: ^14.0.0
   postcss: ^8.5.23
   sharp: ^0.35.3
@@ -1517,7 +1519,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: ^4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4455,8 +4457,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -5580,8 +5582,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6051,8 +6053,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@7.0.2:
@@ -10695,9 +10697,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.3.3
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -11200,7 +11202,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.32)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -11210,7 +11212,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1(supports-color@8.1.1)
       express-rate-limit: 8.6.1(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
-      hono: 4.12.32
+      hono: 4.12.34
       jose: 6.2.4
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -13273,14 +13275,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13561,7 +13563,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14824,7 +14826,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -15362,7 +15364,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.32: {}
+  hono@4.12.34: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -17056,11 +17058,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5(patch_hash=32d5f5d88e8b4b38cb3596270bd0d71e7267ba932937b74599f7100823741f89):
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,9 @@ overrides:
   "undici": "^8.0.0"
   "lodash": "^4.18.0"
   "tmp": "^0.2.6"
-  "brace-expansion": "^5.0.8"
+  "brace-expansion": "^5.0.9"
+  "fast-uri": "^3.1.5"
+  "hono": "^4.12.34"
   "uuid": "^14.0.0"
   # Both of these reach us through next in apps/docs, and bumping next fixes
   # neither. It pins `"postcss": "8.4.31"` exactly and takes `sharp: "^0.34.5"`
@@ -49,6 +51,9 @@ minimumReleaseAgeExclude:
   - "magic-oxfmt-config@1.2.0"
   - "magic-tsconfig@1.2.0"
   - "magic-codemods@1.1.0"
+  - "brace-expansion@5.0.9" # GHSA-rgw5-rvv9-x895
+  - "fast-uri@3.1.5" # GHSA-7p8r-x3mc-p8w7
+  - "hono@4.12.34" # GHSA-8j4g-w8fx-2239
   # Our own plugin, published from this account 2026-07-27 — same first-party
   # exemption the sibling repos carry. Version-pinned like the rest.
   - "eslint-plugin-safe-jsx@1.3.0"


### PR DESCRIPTION
## Summary

Clean installs now resolve every audited dependency to a patched release. The `magic-modal` package still ships only its built output and peer dependency declarations.

## Details

- Moves `fast-uri` to 3.1.5, `brace-expansion` to 5.0.9, and `hono` to 4.12.34.
- Adds workspace overrides so future installs cannot fall back to the vulnerable releases.
- Exempts these same-day security releases from pnpm's 24-hour quarantine.
- The affected paths are repo tooling, docs, and examples.

## Testing steps

1. Use Node 24.18 and install the locked workspace:

    ```sh
    pnpm install --frozen-lockfile
    ```

2. From the repository root, these commands should all exit successfully:

    ```sh
    pnpm run format
    pnpm run lint
    pnpm run typecheck
    pnpm run test
    pnpm run build
    pnpm run doctor
    pnpm run changelog:check
    pnpm run release:check
    pnpm run registry:check
    pnpm --filter @magic-modal/next-web run smoke:browser
    ```

3. Check the dependency report:

    ```sh
    pnpm audit
    ```

    The report should show zero vulnerabilities at every severity.
