### PR TITLE
fix(ci): validate Renovate branches before PR creation

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -5,9 +5,13 @@ on:
       - main
   # Also run on main itself. Publish was the only workflow watching main, so a
   # merge that broke lint or format stayed green until the next PR inherited it.
+  # Renovate uses `prCreation: not-pending`, so its branches need this push run
+  # before the bot can open a PR. Without it, they sit on the dependency
+  # dashboard forever because no status check can start.
   push:
     branches:
       - main
+      - "renovate/**"
 
 # Reads the tree and nothing else. The pnpm and turbo caches go through the
 # Actions cache service on the runtime token. Declared here because a called


### PR DESCRIPTION
## Summary

Renovate branches now run the repository checks as soon as they're pushed, so the bot can open its PR after the checks pass.

## Details

- Adds `renovate/**` to the workflow's push branches.
- Keeps the workflow read-only and leaves the existing pull request and `main` runs unchanged.
- Clears the deadlock between Renovate's `prCreation: not-pending` policy and a workflow that previously had no branch event to run on.

## Testing steps

1. Check the workflow syntax:

```sh
actionlint .github/workflows/branch-validation.yml
```

2. Check the configured push branches:

```sh
node -e 'const fs=require("fs"); const YAML=require("yaml"); const wf=YAML.parse(fs.readFileSync(".github/workflows/branch-validation.yml", "utf8")); const branches=wf.on.push.branches; if (JSON.stringify(branches)!==JSON.stringify(["main","renovate/**"])) process.exit(1)'
```

Both commands should exit with status 0.
