### PR TITLE
chore(deps): update magic tooling

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
     "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.0",
     "gsap": "3.15.0",
     "lucide-react": "^1.25.0",
-    "magic-docs": "1.0.0",
+    "magic-docs": "1.0.5",
     "magic-modal": "workspace:*",
     "next": "16.2.12",
     "react": "19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
     devDependencies:
       magic-codemods:
         specifier: ^1.1.0
-        version: 1.1.0
+        version: 1.1.5
       shadcn:
         specifier: 4.16.1
         version: 4.16.1(supports-color@8.1.1)(typescript@5.9.3)
@@ -59,10 +59,10 @@ importers:
         version: 19.2.18
       magic-oxfmt-config:
         specifier: ^1.2.0
-        version: 1.2.0(oxfmt@0.61.0)
+        version: 1.2.5(oxfmt@0.61.0)
       magic-tsconfig:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.4
       oxfmt:
         specifier: 0.61.0
         version: 0.61.0
@@ -100,8 +100,8 @@ importers:
         specifier: ^1.25.0
         version: 1.28.0(react@19.2.0)
       magic-docs:
-        specifier: 1.0.0
-        version: 1.0.0(11cd9eccae0b310d66e81542a6ac738d)
+        specifier: 1.0.5
+        version: 1.0.5(11cd9eccae0b310d66e81542a6ac738d)
       magic-modal:
         specifier: workspace:*
         version: link:../../packages/modal
@@ -138,13 +138,13 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       magic-oxfmt-config:
         specifier: ^1.2.0
-        version: 1.2.0(oxfmt@0.61.0)
+        version: 1.2.5(oxfmt@0.61.0)
       magic-oxlint-config:
         specifier: ^2.0.0
-        version: 2.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0)
+        version: 2.0.4(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0)
       magic-tsconfig:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.4
       oxfmt:
         specifier: 0.61.0
         version: 0.61.0
@@ -226,13 +226,13 @@ importers:
         version: 1.20.1
       magic-oxfmt-config:
         specifier: ^1.2.0
-        version: 1.2.0(oxfmt@0.60.0)
+        version: 1.2.5(oxfmt@0.60.0)
       magic-oxlint-config:
         specifier: ^1.2.0
         version: 1.2.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.75.0)
       magic-tsconfig:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.4
       oxfmt:
         specifier: 0.60.0
         version: 0.60.0
@@ -266,7 +266,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       magic-oxfmt-config:
         specifier: ^1.2.0
-        version: 1.2.0(oxfmt@0.60.0)
+        version: 1.2.5(oxfmt@0.60.0)
       oxfmt:
         specifier: 0.60.0
         version: 0.60.0
@@ -324,13 +324,13 @@ importers:
         version: 17.0.0
       magic-oxfmt-config:
         specifier: ^1.2.0
-        version: 1.2.0(oxfmt@0.61.0)
+        version: 1.2.5(oxfmt@0.61.0)
       magic-oxlint-config:
         specifier: ^2.0.0
-        version: 2.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0)
+        version: 2.0.4(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0)
       magic-tsconfig:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.4
       oxfmt:
         specifier: 0.61.0
         version: 0.61.0
@@ -409,13 +409,13 @@ importers:
         version: 7.0.0(typescript@5.9.3)
       magic-oxfmt-config:
         specifier: ^1.2.0
-        version: 1.2.0(oxfmt@0.61.0)
+        version: 1.2.5(oxfmt@0.61.0)
       magic-oxlint-config:
         specifier: ^2.0.0
-        version: 2.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0)
+        version: 2.0.4(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0)
       magic-tsconfig:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.4
       oxfmt:
         specifier: 0.61.0
         version: 0.61.0
@@ -6849,13 +6849,13 @@ packages:
     resolution: {integrity: sha512-Lci/1in+elqZ589PXnfP/iwZXpwQifTM94WJRQwG2tZSdfY7NfB/aUaTARHrohWCgHlXoabeaeXRDOnF5X9JQw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  magic-codemods@1.1.0:
-    resolution: {integrity: sha512-u+L9X1yLfZwxwY8lVOpCNgFkzRnFY7TEGahUizkiLgEJyx22jcxRiVKhSj1xz4R469xsRMz4iO5I7VTkY0oP7Q==}
+  magic-codemods@1.1.5:
+    resolution: {integrity: sha512-KszxXtjc4x0iuzlL84kSTlLMncJpQ5blRs8+H8iBO1vulYRegIdtAmwVxLUc195sO+i8o94Kbqszo6tpMDgsxQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  magic-docs@1.0.0:
-    resolution: {integrity: sha512-Bn746g6to8xqgGMqmMDwtKamAgRFdEPp2Q9SG57CXa8TnAx9aDwF8s57eBRniaTCfiYh2SB0XKNKa1cxwGtdTQ==}
+  magic-docs@1.0.5:
+    resolution: {integrity: sha512-+FMaOcPlPXeo0Jd8SoN96oM3b7y23wdgcqJmN02LDHRZm2zKLytBOnLFSebQSVdHSIBulKH756/kzVL+d/A/aQ==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
@@ -6866,8 +6866,8 @@ packages:
       react: ^19.2.0
       react-dom: ^19.2.0
 
-  magic-oxfmt-config@1.2.0:
-    resolution: {integrity: sha512-Wq46MqLnrZTJx1V2nJumdyW8OgA4URnhrfkYx6NYeewQRJAN+wiS1lxu1+5gU6BvlDetmbz7Ol/Xb8sxVXgW3A==}
+  magic-oxfmt-config@1.2.5:
+    resolution: {integrity: sha512-p13sB9X2aqXo78RsQT7j8wPI3omppkUb5Qmp0Ol99dldB1gzWHYeZazhGN29mv9ekephUyRIk5Wtsi/AgtwYFQ==}
     engines: {node: '>=22.18.0'}
     hasBin: true
     peerDependencies:
@@ -6885,8 +6885,8 @@ packages:
       oxlint:
         optional: true
 
-  magic-oxlint-config@2.0.0:
-    resolution: {integrity: sha512-4fyDWv8aWqK14ykjhbSn1xtkOcTlDY1NK3G9h6QaRrcepWZ9bQ89ZduqBc+ZyeE0aoogQvcjS9O9hSfn/6lXIQ==}
+  magic-oxlint-config@2.0.4:
+    resolution: {integrity: sha512-urPfrwREQJMIr8ap1dYEAb9XlJPYbypmSzf/2jmFW25CwiSRE6FEbLjW3FKmJEk8kB1UxLH/s7MUbiiaQ++X6w==}
     engines: {node: '>=22.18.0'}
     peerDependencies:
       oxlint: '>=1.75.0'
@@ -6894,8 +6894,8 @@ packages:
       oxlint:
         optional: true
 
-  magic-oxlint-plugin@1.2.0:
-    resolution: {integrity: sha512-aW8MpAp1uFdEn1xXcIcZR7cI5GE+P/EOjwzEhFi/r0CrFOdIyEVZK9JpmK+P53jmu7c0+x6NlOxS4AY464yqDw==}
+  magic-oxlint-plugin@1.2.4:
+    resolution: {integrity: sha512-kpli3A+pUg5JrR+PTPcCqrnqroGb6hkvINjtX/9xCxs1ceT7CugDdKsQRawsGKURxeHOuPPqyIjcDzbryE+EOg==}
     engines: {node: '>=22'}
     peerDependencies:
       oxlint: '>=1.75.0'
@@ -6909,8 +6909,8 @@ packages:
   magic-string@1.1.0:
     resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
 
-  magic-tsconfig@1.2.0:
-    resolution: {integrity: sha512-odQYUHWzEvgB85RsdRvKwYQPm4/zMMgXABhPPHyNpkEd4T4OqPp8SI4LfYQAn5LXLIktLHzqSJktH5g0Y5EeIQ==}
+  magic-tsconfig@1.2.4:
+    resolution: {integrity: sha512-wDcuTfxZ5OlA1dW8G8ijcyUxOCuuyXzyf3OcyV/6SPrmydkiDQIYGFgV+/VM2VqIdObdGuyMSzKM/KXJiWKJ0w==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -16317,11 +16317,11 @@ snapshots:
 
   macos-release@3.5.1: {}
 
-  magic-codemods@1.1.0:
+  magic-codemods@1.1.5:
     dependencies:
       ts-morph: 28.0.0
 
-  magic-docs@1.0.0(11cd9eccae0b310d66e81542a6ac738d):
+  magic-docs@1.0.5(11cd9eccae0b310d66e81542a6ac738d):
     dependencies:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.18
@@ -16336,11 +16336,11 @@ snapshots:
       - '@types/mdast'
       - supports-color
 
-  magic-oxfmt-config@1.2.0(oxfmt@0.60.0):
+  magic-oxfmt-config@1.2.5(oxfmt@0.60.0):
     optionalDependencies:
       oxfmt: 0.60.0
 
-  magic-oxfmt-config@1.2.0(oxfmt@0.61.0):
+  magic-oxfmt-config@1.2.5(oxfmt@0.61.0):
     optionalDependencies:
       oxfmt: 0.61.0
 
@@ -16353,16 +16353,16 @@ snapshots:
     transitivePeerDependencies:
       - eslint
 
-  magic-oxlint-config@2.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0):
+  magic-oxlint-config@2.0.4(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(oxlint@1.76.0):
     dependencies:
       eslint-plugin-safe-jsx: 1.3.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
-      magic-oxlint-plugin: 1.2.0(oxlint@1.76.0)
+      magic-oxlint-plugin: 1.2.4(oxlint@1.76.0)
     optionalDependencies:
       oxlint: 1.76.0
     transitivePeerDependencies:
       - eslint
 
-  magic-oxlint-plugin@1.2.0(oxlint@1.76.0):
+  magic-oxlint-plugin@1.2.4(oxlint@1.76.0):
     optionalDependencies:
       oxlint: 1.76.0
 
@@ -16374,7 +16374,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magic-tsconfig@1.2.0: {}
+  magic-tsconfig@1.2.4: {}
 
   make-dir@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

The docs app now uses the `magic-docs` release that hardens theme file writes against races.

## Details

- Moves `magic-docs` from 1.0.0 to 1.0.5.
- Refreshes the lockfile resolutions for the shared codemods, formatter, linter, plugin, and TypeScript config packages.
- Pulls in the atomic-write and file-race hardening released in `GSTJ/magic` v1.19.2.
- Leaves the modal packages and their versions unchanged, so this does not cut a package release.

## Testing steps

1. Install the updated dependencies:

```sh
pnpm install --frozen-lockfile
```

It should finish with `Done` and no errors.

2. Build the documentation site:

```sh
pnpm run docs
```

It should list the generated pages and report 37 HTML files with 828 working internal links.

3. Start the built site:

```sh
pnpm --filter @magic-modal/docs exec serve out -l 4173
```

It should accept connections at `http://localhost:4173`.

4. Open `http://localhost:4173/docs/` and confirm the introduction page loads with its navigation and code example.
